### PR TITLE
Add type hints to core base classes and fix mutable defaults

### DIFF
--- a/alphaDeesp/core/elements.py
+++ b/alphaDeesp/core/elements.py
@@ -10,100 +10,107 @@ This file contains substation elements, ie, Objects: Production, Consumption, Li
 """
 
 import logging
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class Production:
-    ID = 0
+    ID: int = 0
 
-    def __init__(self, busbar_id, value=None):
-        # print("Production created...")
-        self.ID = Production.ID
-        self.busbar_id = busbar_id
-        self.value = value
+    def __init__(self, busbar_id: int, value: Optional[float] = None) -> None:
+        self.ID: int = Production.ID
+        self.busbar_id: int = busbar_id
+        self.value: Optional[float] = value
         Production.ID += 1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<< PRODUCTION Object ID: {}, busbar_id: {}, value: {} >>".format(self.ID, self.busbar_id, self.value)
 
     @property
-    def busbar(self):
+    def busbar(self) -> int:
         return self.busbar_id
 
     @busbar.setter
-    def busbar(self, new_busbar):
+    def busbar(self, new_busbar: int) -> None:
         self.busbar_id = new_busbar
 
 
 class Consumption:
-    ID = 0
+    ID: int = 0
 
-    def __init__(self, busbar_id, value=None):
-        # print("Consumption created...")
-        self.ID = Consumption.ID
-        self.busbar_id = busbar_id
-        self.value = value
+    def __init__(self, busbar_id: int, value: Optional[float] = None) -> None:
+        self.ID: int = Consumption.ID
+        self.busbar_id: int = busbar_id
+        self.value: Optional[float] = value
         Consumption.ID += 1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<< CONSUMPTION Object ID: {}, busbar_id: {}, value: {} >>".format(self.ID, self.busbar_id, self.value)
 
     @property
-    def busbar(self):
+    def busbar(self) -> int:
         return self.busbar_id
 
     @busbar.setter
-    def busbar(self, new_busbar):
+    def busbar(self, new_busbar: int) -> None:
         logger.debug("busbar setter, new busbar = %s", new_busbar)
         self.busbar_id = new_busbar
 
 
 class OriginLine:
-    ID = 0
+    ID: int = 0
 
-    def __init__(self, busbar_id, end_substation_id=None, flow_value=None):
-        # print("OriginLine created...")
-        self.ID = OriginLine.ID
-        self.busbar_id = busbar_id
-        self.end_substation_id = end_substation_id
-        self.flow_value = flow_value
+    def __init__(
+        self,
+        busbar_id: int,
+        end_substation_id: Optional[int] = None,
+        flow_value: Optional[List[float]] = None,
+    ) -> None:
+        self.ID: int = OriginLine.ID
+        self.busbar_id: int = busbar_id
+        self.end_substation_id: Optional[int] = end_substation_id
+        self.flow_value: Optional[List[float]] = flow_value
         OriginLine.ID += 1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<< ORIGINLINE Object ID: {}, busbar_id: {}," \
                " connected to substation: {}, flow_value: {} >>".format(self.ID, self.busbar_id, self.end_substation_id,
                                                                         self.flow_value)
 
     @property
-    def busbar(self):
+    def busbar(self) -> int:
         return self.busbar_id
 
     @busbar.setter
-    def busbar(self, new_busbar):
+    def busbar(self, new_busbar: int) -> None:
         self.busbar_id = new_busbar
 
 
 class ExtremityLine:
-    ID = 0
+    ID: int = 0
 
-    def __init__(self, busbar_id, start_substation_id=None, flow_value=None):
-        # print("ExtremityLine created...")
-        self.ID = ExtremityLine.ID
-        self.busbar_id = busbar_id
-        self.start_substation_id = start_substation_id
-        self.flow_value = flow_value
+    def __init__(
+        self,
+        busbar_id: int,
+        start_substation_id: Optional[int] = None,
+        flow_value: Optional[List[float]] = None,
+    ) -> None:
+        self.ID: int = ExtremityLine.ID
+        self.busbar_id: int = busbar_id
+        self.start_substation_id: Optional[int] = start_substation_id
+        self.flow_value: Optional[List[float]] = flow_value
         ExtremityLine.ID += 1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<< EXTREMITYLINE Object ID: {}, busbar_id: {}," \
                " connected to substation: {}, flow_value: {} >>".format(self.ID, self.busbar_id,
                                                                         self.start_substation_id, self.flow_value)
 
     @property
-    def busbar(self):
+    def busbar(self) -> int:
         return self.busbar_id
 
     @busbar.setter
-    def busbar(self, new_busbar):
+    def busbar(self, new_busbar: int) -> None:
         self.busbar_id = new_busbar

--- a/alphaDeesp/core/grid2op/Grid2opSimulation.py
+++ b/alphaDeesp/core/grid2op/Grid2opSimulation.py
@@ -56,12 +56,14 @@ class Grid2opSimulation(Simulation):
     def get_layout(self):
         return self.layout
 
-    def __init__(self, obs, action_space, observation_space, param_options=None, debug = False, ltc=[9],other_ltc=[], plot=False, plot_folder = None,reward_type=None,simu_step=0):
+    def __init__(self, obs, action_space, observation_space, param_options=None, debug=False, ltc=None, other_ltc=None, plot=False, plot_folder=None, reward_type=None, simu_step=0):
         super().__init__()
 
         # Get Grid2op objects
         if ltc is None:
             ltc = [9]
+        if other_ltc is None:
+            other_ltc = []
         self.plot_folder=None
         if plot: # Manual mode
             self.plot_folder = plot_folder

--- a/alphaDeesp/core/pypownet/PypownetSimulation.py
+++ b/alphaDeesp/core/pypownet/PypownetSimulation.py
@@ -17,12 +17,15 @@ from alphaDeesp.core.printer import Printer
 
 
 class PypownetSimulation(Simulation):
-    def __init__(self, env, obs, action_space, param_options=None, debug=False, ltc=[9], plot_folder = None,isScoreFromBackend=False):
+    def __init__(self, env, obs, action_space, param_options=None, debug=False, ltc=None, plot_folder=None, isScoreFromBackend=False):
         super().__init__()
         print("PypownetSimulation object created...")
 
         if not param_options or param_options is None:
             raise AttributeError("\nparam_options are empty or None, meaning the config file is not properly read.")
+
+        if ltc is None:
+            ltc = [9]
 
         self.save_bag = []
         self.debug = debug

--- a/alphaDeesp/core/simulation.py
+++ b/alphaDeesp/core/simulation.py
@@ -9,24 +9,29 @@
 import logging
 from abc import ABC, abstractmethod
 from math import fabs
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
 import numpy as np
 
 import pandas as pd
 
-from alphaDeesp.core.elements import ExtremityLine, OriginLine
+from alphaDeesp.core.elements import Consumption, ExtremityLine, OriginLine, Production
 
 logger = logging.getLogger(__name__)
+
+# Convenience alias for the heterogeneous per-substation element lists.
+SubstationElement = Union[Production, Consumption, OriginLine, ExtremityLine]
 
 
 class Simulation(ABC):
     """Abstract Class Simulation"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
     @abstractmethod
-    def cut_lines_and_recomputes_flows(self, ids: list):
+    def cut_lines_and_recomputes_flows(self, ids: List[int]) -> Sequence[float]:
         """Disconnect the lines identified by ``ids`` and re-run a power flow.
 
         Implementations must not mutate the long-lived simulation state
@@ -42,7 +47,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def isAntenna(self):
+    def isAntenna(self) -> Optional[int]:
         """Return the substation id of an antenna attached to the overloaded line, if any.
 
         An "antenna" is a substation where the overloaded line is the only
@@ -55,7 +60,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def isDoubleLine(self):
+    def isDoubleLine(self) -> Optional[List[int]]:
         """Return the list of parallel lines sharing the endpoints of the overloaded line.
 
         Two substations may be connected by more than one line ("double
@@ -68,7 +73,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def getLinesAtSubAndBusbar(self):
+    def getLinesAtSubAndBusbar(self) -> Dict[Any, List[int]]:
         """Return the lines connected to each endpoint substation, grouped by busbar.
 
         Used by :meth:`isAntenna` and by the ranking step to count the
@@ -80,7 +85,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_layout(self):
+    def get_layout(self) -> List[Tuple[float, float]]:
         """Return the 2D coordinates of each substation for plotting.
 
         :returns: A list of ``(x, y)`` tuples, one per substation, in the
@@ -88,7 +93,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_substation_in_cooldown(self):
+    def get_substation_in_cooldown(self) -> List[int]:
         """Return substations that cannot be acted upon at the current timestep.
 
         Some backends (notably Grid2op) enforce a cooldown period after a
@@ -99,7 +104,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_substation_elements(self):
+    def get_substation_elements(self) -> Dict[int, List[SubstationElement]]:
         """Return the per-substation element model built from the observation.
 
         Each element is an instance of one of the classes in
@@ -112,7 +117,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_substation_to_node_mapping(self):
+    def get_substation_to_node_mapping(self) -> Optional[Dict[int, Any]]:
         """Return the mapping from substation ids to overflow-graph node ids.
 
         Depending on the backend a substation may map to one or two nodes
@@ -125,7 +130,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_internal_to_external_mapping(self):
+    def get_internal_to_external_mapping(self) -> Dict[int, int]:
         """Return the translation table from internal node ids to backend ids.
 
         AlphaDeesp renumbers substations densely starting at 0 for its
@@ -137,7 +142,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_dataframe(self):
+    def get_dataframe(self) -> pd.DataFrame:
         """Return the main topology + flow dataframe produced by :meth:`create_df`.
 
         The dataframe has one row per line of the grid and at least the
@@ -149,7 +154,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_reference_topovec_sub(self, sub):
+    def get_reference_topovec_sub(self, sub: int) -> List[int]:
         """Return the all-on-busbar-1 topology vector for substation ``sub``.
 
         AlphaDeesp uses this vector as the "do nothing" reference when
@@ -162,7 +167,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def get_overload_disconnection_topovec_subor(self, l):
+    def get_overload_disconnection_topovec_subor(self, l: int) -> Tuple[int, List[int]]:
         """Return the topology vector that disconnects the origin side of line ``l``.
 
         This is used to simulate a line-opening action as a degenerate
@@ -176,7 +181,7 @@ class Simulation(ABC):
         """
 
     @staticmethod
-    def create_end_result_empty_dataframe():
+    def create_end_result_empty_dataframe() -> pd.DataFrame:
         """This function creates initial structure for the dataframe"""
 
         end_result_dataframe_structure_initiation = {
@@ -199,7 +204,7 @@ class Simulation(ABC):
 
         return end_result_data_frame
 
-    def create_df(self, d: dict, line_to_cut: list):
+    def create_df(self, d: Dict[str, Any], line_to_cut: List[int]) -> pd.DataFrame:
         """arg: d represents a topology"""
         # HERE WE CREATE DATAFRAME
         df = pd.DataFrame(d["edges"])
@@ -288,7 +293,7 @@ class Simulation(ABC):
         return df
 
     @staticmethod
-    def branch_direction_swaps(df):
+    def branch_direction_swaps(df: pd.DataFrame) -> None:
         """we parse self.df and invert branches init_flows < 0"""
         swapped = []
         for i, row in df.iterrows():
@@ -312,11 +317,16 @@ class Simulation(ABC):
         df["swapped"] = swapped
 
     @staticmethod
-    def invert_dict_keys_values(d):
+    def invert_dict_keys_values(d: Dict[Any, Any]) -> Dict[Any, Any]:
         return dict([(v, k) for k, v in d.items()])
 
     @staticmethod
-    def get_model_obj_from_or(df_indexed, substation_id, dest, busbar):
+    def get_model_obj_from_or(
+        df_indexed: pd.DataFrame,
+        substation_id: int,
+        dest: int,
+        busbar: int,
+    ) -> Optional[Union[OriginLine, ExtremityLine]]:
         try:
             # Case 1: Direct Match
             val = df_indexed.loc[(substation_id, dest), 'delta_flows']
@@ -351,7 +361,12 @@ class Simulation(ABC):
                 return None
 
     @staticmethod
-    def get_model_obj_from_ext(df_indexed, substation_id, dest, busbar):
+    def get_model_obj_from_ext(
+        df_indexed: pd.DataFrame,
+        substation_id: int,
+        dest: int,
+        busbar: int,
+    ) -> Optional[Union[OriginLine, ExtremityLine]]:
         """
         Optimized version using Pandas MultiIndex, robust against Duplicate Rows.
         """

--- a/docs/code-quality-analysis.md
+++ b/docs/code-quality-analysis.md
@@ -1,10 +1,14 @@
 # Code Quality & Maintainability Analysis
 
-_Last updated: 2026-04-12 — longer-term refactors for the four highest-CC
-functions and the `"666"` twin-node encoding landed on branch
-`claude/refactor-rank-topo-function-U4y9g`. Short-term action plan landed on
-`claude/code-quality-short-term-tnydm`; original immediate-cleanup pass on
-`claude/code-quality-analysis-8Ftgi`._
+_Last updated: 2026-04-12 — high-impact items 5, 6, 7 and 9 are now all
+resolved on branch `claude/fix-code-quality-issues-XGpMU` (type hints on
+`core/simulation.py` and `core/elements.py`; remaining mutable defaults on
+`Grid2opSimulation.__init__` / `PypownetSimulation.__init__`; items 5 and 7
+were already done in prior passes and are reconfirmed). Longer-term refactors
+for the four highest-CC functions and the `"666"` twin-node encoding landed
+on branch `claude/refactor-rank-topo-function-U4y9g`. Short-term action plan
+landed on `claude/code-quality-short-term-tnydm`; original immediate-cleanup
+pass on `claude/code-quality-analysis-8Ftgi`._
 
 This document captures a diagnostic review of the `alphaDeesp` (ExpertOp4Grid)
 codebase. It is intended as a living punch-list for incremental cleanup work.
@@ -94,6 +98,8 @@ and discrimination are covered in `TestTwinNodeIds`.
 | done | Write real docstrings for every abstract method in `core/simulation.py` | Replaced 9 `"""TODO"""` stubs with full contract documentation |
 | done | Re-enable the three excluded test modules in CI (or document why) | Tests now self-skip via `pytest.importorskip`; `--ignore` flags removed |
 | done | Unify `LICENSE`/`LICENSE.md`; refresh `setup.py` classifiers and version pins | See "Packaging cleanup" below |
+| done | Fix remaining mutable defaults on `Grid2opSimulation.__init__` / `PypownetSimulation.__init__` | See "Mutable defaults" below |
+| done | Type hints seed on `core/simulation.py` and `core/elements.py` | See "Type hints seed" below |
 
 ### Bare except cleanup
 
@@ -180,9 +186,80 @@ Two mutable defaults in `alphaDeesp/core/alphadeesp.py`:
   `None`.
 
 The `ltc=[9]` / `other_ltc=[]` defaults on `Grid2opSimulation.__init__` and
-`PypownetSimulation.__init__` are **not** fixed yet — they are part of the
-simulator public API and fixing them cleanly needs a careful scan of the
-call sites. Tracked under the short-term action plan below.
+the `ltc=[9]` default on `PypownetSimulation.__init__` are now also fixed.
+Both signatures take `ltc=None` / `other_ltc=None` and normalize to `[9]` /
+`[]` inside the body; all in-tree callers pass these as keyword arguments
+(verified across `main.py`, `agent_call.py`, the three grid2op test
+modules, `Expert_rule_action_verification.py` and the four
+`getting_started/` notebooks), so the signature change is source-compatible
+for embedders too.
+
+### Type hints seed
+
+`core/elements.py` and `core/simulation.py` — the two modules the original
+audit flagged as the highest-leverage starting points — are now fully
+type-annotated. The rest of the package is still untyped; the two files
+above are intended as a **seed** the rest of the code can be annotated
+against without chasing `Any` through every call site.
+
+What landed:
+
+- `core/elements.py`:
+  - `Production.__init__(self, busbar_id: int, value: Optional[float] = None) -> None`
+  - `Consumption.__init__(self, busbar_id: int, value: Optional[float] = None) -> None`
+  - `OriginLine.__init__(self, busbar_id: int, end_substation_id: Optional[int] = None, flow_value: Optional[List[float]] = None) -> None`
+  - `ExtremityLine.__init__(self, busbar_id: int, start_substation_id: Optional[int] = None, flow_value: Optional[List[float]] = None) -> None`
+  - `ID: int` class variable annotation on each of the four classes.
+  - `busbar` property / setter typed as `int` on all four classes.
+  - `__repr__(self) -> str` on all four classes.
+  - The three ``# print("... created...")`` commented-out debug stubs that
+    had been sitting at the top of each ``__init__`` were dropped along the
+    way — they were dead and made the type annotations noisier to read.
+
+- `core/simulation.py`:
+  - `Simulation.__init__(self) -> None`.
+  - All 10 abstract methods carry concrete return types:
+    `cut_lines_and_recomputes_flows -> Sequence[float]`,
+    `isAntenna -> Optional[int]`,
+    `isDoubleLine -> Optional[List[int]]`,
+    `getLinesAtSubAndBusbar -> Dict[Any, List[int]]`,
+    `get_layout -> List[Tuple[float, float]]`,
+    `get_substation_in_cooldown -> List[int]`,
+    `get_substation_elements -> Dict[int, List[SubstationElement]]`,
+    `get_substation_to_node_mapping -> Optional[Dict[int, Any]]`,
+    `get_internal_to_external_mapping -> Dict[int, int]`,
+    `get_dataframe -> pd.DataFrame`,
+    `get_reference_topovec_sub(sub: int) -> List[int]`,
+    `get_overload_disconnection_topovec_subor(l: int) -> Tuple[int, List[int]]`.
+  - Concrete helpers: `create_df(self, d: Dict[str, Any], line_to_cut: List[int]) -> pd.DataFrame`,
+    `branch_direction_swaps(df: pd.DataFrame) -> None`,
+    `invert_dict_keys_values(d: Dict[Any, Any]) -> Dict[Any, Any]`,
+    `create_end_result_empty_dataframe() -> pd.DataFrame`,
+    `get_model_obj_from_or/ext(df_indexed: pd.DataFrame, substation_id: int, dest: int, busbar: int) -> Optional[Union[OriginLine, ExtremityLine]]`.
+  - A module-level ``SubstationElement = Union[Production, Consumption,
+    OriginLine, ExtremityLine]`` alias is exposed so downstream annotations
+    can use a single name instead of repeating the 4-way union.
+
+Deliberately out of scope for this pass (tracked under longer-term item 14):
+
+- `core/alphadeesp.py`, `core/graphsAndPaths.py`, `core/network.py`,
+  `core/printer.py`, and the two concrete backends
+  (`core/grid2op/Grid2opSimulation.py`, `core/pypownet/PypownetSimulation.py`).
+  These modules consume the seed types but annotating them requires
+  carefully typing `networkx.DiGraph` / `rustworkx.PyDiGraph` nodes and
+  edges, which is a larger job.
+- Wiring `mypy --ignore-missing-imports` into CI. With only the two seed
+  modules annotated mypy would be almost entirely noise; it makes sense to
+  enable it once `alphadeesp.py` and the backends are typed.
+
+Verification:
+
+- `python -m pyflakes alphaDeesp/core alphaDeesp/*.py` (CI lint scope) →
+  **0 findings**.
+- `python -m pytest alphaDeesp/tests/test_graphs_and_paths_unit.py
+  alphaDeesp/tests/test_alphadeesp_unit.py` → **130 passed**.
+- `from alphaDeesp.core import simulation, elements` imports clean on
+  Python 3.12 with numpy / pandas installed.
 
 ### `Simulation.create_df` stdout spam
 
@@ -347,17 +424,17 @@ CI-config change.
 | Average complexity | **B (5.72)** across 163 functions/classes | `radon cc` |
 | `print()` calls | baseline: **247** across 20 files → **~108 remaining** (tests, `build_new_parameters_environment.py`, legacy Pypownet backend, `Expert_rule_action_verification.py`); all 10 CI-scoped first-party modules are at **0** | grep |
 | Bare `except:` clauses | baseline: 9 → **0** | grep |
-| Type-annotated functions | **1** across the entire codebase | grep `-> ` |
+| Type-annotated functions | baseline 1 → **36** after the core base-class seed (16 in `core/elements.py` + 20 in `core/simulation.py`); rest of the package still untyped | grep `-> ` |
 | Pyflakes findings | baseline: 59 → **0** in CI scope | `pyflakes` |
 | TODO/FIXME markers | 25 across 7 files | grep |
 | Test functions | 164 across 9 files; CI now only excludes `test_cli.py` (run as a dedicated step); pypownet + expert_rules self-skip via `pytest.importorskip` | `.circleci/config.yml` |
 
 ## Critical issues (fix first)
 
-> Items 1, 2, 3, 4, 8 and 10 below are now resolved and are kept for
-> historical context — see the "Cleanup progress" section at the top.
-> Items 5, 6, 7, 9, 11+ remain as targets for the remaining longer-term
-> refactors.
+> Items 1–10 below are now resolved and are kept for historical context —
+> see the "Cleanup progress" section at the top. Items 11+ remain as
+> targets for the remaining longer-term refactors (14: type hints beyond
+> the core base classes; 15: Pypownet backend fate).
 
 ### 1. Bare `except:` clauses swallowing all errors
 `alphaDeesp/main.py` (×3 near lines 100, 105, 117),
@@ -403,44 +480,44 @@ CI**. The CLI is re-added as a separate job, but `test_expert_rules.py`
 
 ## High-impact issues
 
-### 5. No logging — 247 `print()` calls
-Distribution: `PypownetSimulation.py` (42), `alphadeesp.py` (39),
-`Expert_rule_action_verification.py` (34), `main.py` (14),
-`Grid2opSimulation.py` (12). There is no verbosity control; `-d/--debug` is
-checked in only a few places. Embedders (e.g. l2rpn-baselines `ExpertAgent`)
-cannot suppress output. Replace with `logging.getLogger(__name__)`.
+### 5. ~~No logging — 247 `print()` calls~~ (done)
+Replaced with module-level `logging.getLogger(__name__)` across the 10
+first-party modules in the CI scope. See the "Logging migration" section
+near the top of this document. Embedders can now silence the expert system
+with a single `logging.getLogger("alphaDeesp").setLevel(logging.WARNING)`.
 
-### 6. Zero type hints
-Exactly one `-> ` return annotation in the whole package. Given how much of
-the code manipulates `pd.DataFrame`, `networkx.DiGraph`, and custom
-`OriginLine`/`ExtremityLine` objects, this is the largest onboarding cost.
-Start by annotating `core/simulation.py` (the abstract base) and
-`core/elements.py` — they propagate outward.
+### 6. ~~Zero type hints~~ (done for the core base classes)
+`core/elements.py` and `core/simulation.py` — the two starting points the
+original analysis recommended — are now fully annotated. All four element
+classes (`Production`, `Consumption`, `OriginLine`, `ExtremityLine`) carry
+annotations on constructors, the `busbar` property/setter, and the `ID`
+class variable. `Simulation` has annotated signatures for all 10 abstract
+methods, `create_df`, `branch_direction_swaps`, `invert_dict_keys_values`,
+and both `get_model_obj_from_*` helpers. A `SubstationElement` `Union`
+alias is exported from `simulation.py` so downstream code (the two
+backends) can use the same type in their own annotations as they are
+converted. See "Type hints seed" below. Further propagation to
+`alphadeesp.py`, `network.py`, `graphsAndPaths.py` and the backend
+simulators is tracked under longer-term item 14.
 
-### 7. Pyflakes: 15+ dead locals and unused imports in `alphadeesp.py` alone
-Unused imports: `pprint`, `math.ceil`, `os`. Unused locals include
-`ranked_combinations` (line 50), `current_node`/`new_node` (271-272),
-`edge_color` (336), `all_nodes_value_attributes` (385, 758),
-`not_interesting_bus_id` (428), `node2` (555), `p` (823), `indexEdge_inDf`
-(805). This is abandoned refactoring. Similar patterns in `graphsAndPaths.py`
-(5 dead locals), `printer.py` (3 unused imports + 2 dead locals),
-`Expert_rule_action_verification.py` (redefinition of `version_packaging`).
+### 7. ~~Pyflakes: 15+ dead locals and unused imports in `alphadeesp.py` alone~~ (done)
+See the "Pyflakes cleanup" section near the top of this document.
+Reconfirmed: `python -m pyflakes` on the CI scope reports **0 findings**
+after the item 6/9 edits.
 
 ### 8. Abstract-method docstrings are just `"""TODO"""`
 `core/simulation.py:29-70` — 9 of 10 abstract methods have `"""TODO"""` as the
 entire contract documentation. New backend authors have nothing to implement
 against. The class is the public extension point; this is a doc-gap bug.
 
-### 9. Mutable default arguments
-`core/alphadeesp.py:28`:
-
-```python
-def __init__(self, _g, df_of_g, simulator_data=None,
-             substation_in_cooldown=[], debug=False):
-```
-
-and `rank_current_topo_at_node_x(..., topo_vect=[0, 0, 1, 1, 1], ...)`.
-Classic Python footgun that silently leaks state across calls.
+### 9. ~~Mutable default arguments~~ (done)
+The two remaining `ltc=[9]` / `other_ltc=[]` defaults on
+`Grid2opSimulation.__init__` and the `ltc=[9]` default on
+`PypownetSimulation.__init__` are now `None` sentinels normalized inside
+the body. Together with the prior `AlphaDeesp.__init__` /
+`rank_current_topo_at_node_x` fixes this closes out the original audit
+finding. See "Mutable defaults" above (updated) for the full list of
+signatures.
 
 ## Medium-impact issues
 
@@ -543,7 +620,10 @@ details of each change.
 13. ~~Replace the `"666"` twin-node encoding with a proper id scheme.~~ Done,
     see `alphaDeesp/core/twin_nodes.py`.
 14. Add type hints starting from `core/simulation.py` and `core/elements.py`
-    outward; enable `mypy --ignore-missing-imports` in CI.
+    outward; enable `mypy --ignore-missing-imports` in CI. _Seed done for
+    the two base-class modules — see "Type hints seed" above. Remaining:
+    `core/alphadeesp.py`, `core/graphsAndPaths.py`, `core/network.py`,
+    `core/printer.py`, and the two concrete simulator backends._
 15. Decide the fate of the Pypownet backend: first-class (re-enable CI,
     modernize) or deprecated.
 


### PR DESCRIPTION
## Summary

This PR completes two high-impact code quality items from the audit: adding type annotations to the core base-class modules (`core/elements.py` and `core/simulation.py`) and fixing the remaining mutable default arguments in the simulator backends.

## Key Changes

### Type Hints Seed (`core/elements.py` and `core/simulation.py`)

- **`core/elements.py`**: Fully annotated all four element classes (`Production`, `Consumption`, `OriginLine`, `ExtremityLine`)
  - Constructor parameters and return types
  - `ID` class variable and instance attributes
  - `busbar` property getter/setter
  - `__repr__` methods
  - Removed dead commented-out debug print stubs

- **`core/simulation.py`**: Fully annotated the abstract base class
  - All 10 abstract methods with concrete return types (`Sequence[float]`, `Optional[int]`, `Dict[Any, List[int]]`, etc.)
  - Helper methods: `create_df`, `branch_direction_swaps`, `invert_dict_keys_values`, `get_model_obj_from_or/ext`
  - Static factory method `create_end_result_empty_dataframe`
  - Exported `SubstationElement` type alias (`Union[Production, Consumption, OriginLine, ExtremityLine]`) for downstream use

### Mutable Defaults Fixed

- **`Grid2opSimulation.__init__`**: Changed `ltc=[9]` and `other_ltc=[]` to `ltc=None` and `other_ltc=None`, with normalization inside the body
- **`PypownetSimulation.__init__`**: Changed `ltc=[9]` to `ltc=None`, with normalization inside the body
- All in-tree callers verified to use keyword arguments, ensuring source compatibility for embedders

## Implementation Details

- Type annotations use standard library `typing` module (`List`, `Optional`, `Dict`, `Sequence`, `Tuple`, `Union`, `Any`)
- The two seed modules are intentionally scoped to avoid chasing `Any` through untyped code; further propagation to `alphadeesp.py`, `network.py`, `graphsAndPaths.py`, and the backends is tracked as a longer-term item
- Verification: `pyflakes` reports 0 findings on CI scope; all 130 tests pass; imports clean on Python 3.12

## Documentation

Updated `docs/code-quality-analysis.md` to reflect completion of items 5, 6, 7, and 9 from the original audit, with detailed sections on the type hints seed and mutable defaults fixes.

https://claude.ai/code/session_0124sJqybNpDCHzsxiwMRj3w