### PR TITLE
Add type hints propagation and mypy/radon to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install graphviz
       - run: pip install -r requirements.txt
-      - run: pip install pyflakes
+      - run: pip install pyflakes mypy radon
       - run: pip install .
       - run:
           name: Run pyflakes (lint)
@@ -51,6 +51,50 @@ jobs:
               alphaDeesp/core/grid2op/Grid2opObservationLoader.py \
               alphaDeesp/expert_operator.py \
               alphaDeesp/main.py
+      - run:
+          name: Run mypy (static type check)
+          # Config lives in `setup.cfg` (ignore_missing_imports = True etc).
+          # Two modules are enforced strictly — `core/simulation.py` and
+          # `core/elements.py` — via per-module overrides; the rest of the
+          # tree still runs mypy but in permissive mode so annotations can
+          # be rolled out incrementally. `|| true` keeps mypy findings
+          # informational for the untyped modules until the full codebase
+          # catches up.
+          command: |
+            python -m mypy \
+              alphaDeesp/core/simulation.py \
+              alphaDeesp/core/elements.py
+            python -m mypy \
+              alphaDeesp/core/network.py \
+              alphaDeesp/core/printer.py \
+              alphaDeesp/core/alphadeesp.py \
+              alphaDeesp/core/graphsAndPaths.py \
+              alphaDeesp/core/twin_nodes.py \
+              alphaDeesp/core/grid2op/Grid2opSimulation.py \
+              alphaDeesp/core/grid2op/Grid2opObservationLoader.py \
+              alphaDeesp/expert_operator.py \
+              alphaDeesp/main.py || true
+      - run:
+          name: Code quality metrics (radon)
+          # Radon reports cyclomatic complexity, maintainability index, and
+          # raw metrics so the baseline tracked in
+          # docs/code-quality-analysis.md stays visible per build. These
+          # commands are *reporting only* — they never fail the build.
+          command: |
+            echo "=== Cyclomatic complexity (A-F, min: C) ==="
+            python -m radon cc -a -s --min C \
+              alphaDeesp/core/ \
+              alphaDeesp/Expert_rule_action_verification.py || true
+            echo ""
+            echo "=== Maintainability Index (all modules) ==="
+            python -m radon mi -s \
+              alphaDeesp/core/ \
+              alphaDeesp/Expert_rule_action_verification.py || true
+            echo ""
+            echo "=== Raw metrics (SLOC / comment ratio) ==="
+            python -m radon raw -s \
+              alphaDeesp/core/ \
+              alphaDeesp/Expert_rule_action_verification.py || true
       - run:
           name: Run tests
           # `test_cli.py` is run in its own dedicated step below (it spawns a

--- a/alphaDeesp/core/alphadeesp.py
+++ b/alphaDeesp/core/alphadeesp.py
@@ -8,6 +8,7 @@
 
 """ This file is the main file for the Expert Agent called AlphaDeesp """
 import logging
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import networkx as nx
 import pandas as pd
@@ -28,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class AlphaDeesp:  # AKA SOLVER
-    def __init__(self, _g, df_of_g, simulator_data=None, substation_in_cooldown=None, debug=False):
+    def __init__(self, _g: nx.MultiDiGraph, df_of_g: pd.DataFrame, simulator_data: Optional[Dict[str, Any]] = None, substation_in_cooldown: Optional[List[int]] = None, debug: bool = False) -> None:
         # used for postprocessing
         self.bag_of_graphs = {}
         self.debug = debug
@@ -76,18 +77,18 @@ class AlphaDeesp:  # AKA SOLVER
 
         # self.simulate_network_change(self.ranked_combinations)
 
-    def load2(self, observation, line_to_cut: int):
+    def load2(self, observation: Any, line_to_cut: int) -> None:
         """@:arg observation: a pypownet observation,
         line_to_cut: line to cut for overload graph"""
 
-    def simulate_network_change(self, ranked_combinations):
+    def simulate_network_change(self, ranked_combinations: Any) -> None:
         """This function takes a dataFrame ranked_combinations and computes new changes with Pypownet"""
         pass
 
-    def get_ranked_combinations(self):
+    def get_ranked_combinations(self) -> List[pd.DataFrame]:
         return self.ranked_combinations
 
-    def compute_best_topologies(self):
+    def compute_best_topologies(self) -> List[pd.DataFrame]:
         """
         inputs: selected_ranked_nodes (after having identified routing buses, ie 4 categories)
         :return: pd.DataFrame containing all topologies scored.
@@ -124,7 +125,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return res_container
 
-    def clean_and_sort_best_topologies(self, best_topologies):
+    def clean_and_sort_best_topologies(self, best_topologies: pd.DataFrame) -> pd.DataFrame:
         """This function cleans the Dataframe best_topologies;
         it deletes rows with XX, and sorts the Dataframe. In order to achieve this we have to set_index first."""
         best_topologies = best_topologies.set_index("score")
@@ -133,7 +134,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return best_topologies
 
-    def compute_all_combinations(self, node):
+    def compute_all_combinations(self, node: int) -> List[Any]:
         """ Given a node, returns all possible combinations of a node configuration.
         ex: [001], [010], [100], [101], [011]... etc..."""
 
@@ -172,7 +173,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return uniqueComb
 
-    def legal_comb(self,comb,nProd_loads,n_elements,node_configuration,node_configuration_sym):
+    def legal_comb(self, comb: List[int], nProd_loads: int, n_elements: int, node_configuration: List[int], node_configuration_sym: List[int]) -> bool:
         sum_comb=np.sum(comb)
         busBar_prods_loads=set(comb[0:nProd_loads])
         busBar_lines = set(comb[nProd_loads:])
@@ -188,7 +189,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return legal_condition
 
-    def rank_topologies(self, all_combinations, graph, node_to_change: int):
+    def rank_topologies(self, all_combinations: List[Any], graph: nx.MultiDiGraph, node_to_change: int) -> pd.DataFrame:
         """==> ultimate goal: This function returns a DF with topologies ranked
         for the moment:
             takes a topo,
@@ -225,7 +226,7 @@ class AlphaDeesp:  # AKA SOLVER
         return ranked_combinations
 
     # WARNING: does not work yet when you go back from two nodes to one node at a given substation? Basically one node will be not connected?
-    def apply_new_topo_to_graph(self, graph: nx.MultiDiGraph, new_topology, node_to_change: int):
+    def apply_new_topo_to_graph(self, graph: nx.MultiDiGraph, new_topology: List[int], node_to_change: int) -> Tuple[nx.MultiDiGraph, Dict[Any, Any]]:
         """
         Apply a busbar reassignment to ``graph``.
 
@@ -276,7 +277,7 @@ class AlphaDeesp:  # AKA SOLVER
     # Helpers for apply_new_topo_to_graph
     # ------------------------------------------------------------------
 
-    def _gather_edge_colors(self):
+    def _gather_edge_colors(self) -> Dict[Tuple[Any, Any, Any], Any]:
         """
         Snapshot the color of every edge of ``self.g`` before the graph is
         mutated. For edges marked as ``swapped`` in ``self.df`` we also store
@@ -292,7 +293,7 @@ class AlphaDeesp:  # AKA SOLVER
         return color_edges
 
     @staticmethod
-    def _compute_prod_load_per_bus(elements):
+    def _compute_prod_load_per_bus(elements: Iterable[Any]) -> Tuple[Dict[int, float], Dict[int, float]]:
         """
         Sum production and consumption values per ``busbar_id`` for the
         given iterable of ``elements``. Returns ``(prod, load)`` dicts where
@@ -308,7 +309,7 @@ class AlphaDeesp:  # AKA SOLVER
         return prod, load
 
     @staticmethod
-    def _classify_bus(bus_id, prod, load):
+    def _classify_bus(bus_id: int, prod: Dict[int, float], load: Dict[int, float]) -> Tuple[Optional[str], float]:
         """
         Return ``(kind, prod_minus_load)`` for ``bus_id`` where ``kind`` is
         ``"prod"``, ``"load"`` or ``None`` (neither production nor load).
@@ -324,7 +325,7 @@ class AlphaDeesp:  # AKA SOLVER
             return "load", load[bus_id]
         return None, 0
 
-    def _add_bus_nodes(self, graph, bus_ids, prod, load, node_to_change, new_node_id):
+    def _add_bus_nodes(self, graph: nx.MultiDiGraph, bus_ids: Iterable[int], prod: Dict[int, float], load: Dict[int, float], node_to_change: int, new_node_id: Any) -> None:
         """
         Re-add the (up to two) graph nodes corresponding to the new topology,
         styled by their net prod/load balance.
@@ -346,8 +347,8 @@ class AlphaDeesp:  # AKA SOLVER
                                value=str(prod_minus_load),
                                style="filled", fillcolor="#ffffff")
 
-    def _reconnect_bus_edges(self, graph, new_topology, element_types,
-                             node_to_change, new_node_id, color_edges):
+    def _reconnect_bus_edges(self, graph: nx.MultiDiGraph, new_topology: List[int], element_types: List[Any],
+                             node_to_change: int, new_node_id: Any, color_edges: Dict[Tuple[Any, Any, Any], Any]) -> None:
         """
         Re-add every line edge between the (possibly split) substation and
         its neighbours, using the memoised ``color_edges`` for styling.
@@ -379,8 +380,8 @@ class AlphaDeesp:  # AKA SOLVER
                                color=color, fontsize=10,
                                penwidth="%.2f" % penwidth)
 
-    def rank_current_topo_at_node_x(self, graph, node: int, isSingleNode=False, topo_vect=None,
-                                    is_score_specific_substation=True):
+    def rank_current_topo_at_node_x(self, graph: nx.MultiDiGraph, node: int, isSingleNode: bool = False, topo_vect: Optional[List[int]] = None,
+                                    is_score_specific_substation: bool = True) -> Any:
         """
         Rank a candidate topology at ``node`` by scoring how much it relieves
         the overloaded constrained path.
@@ -422,9 +423,9 @@ class AlphaDeesp:  # AKA SOLVER
     # Helpers for rank_current_topo_at_node_x
     # ------------------------------------------------------------------
 
-    def _pick_interesting_bus_id(self, graph, node, topo_vect, isSingleNode,
-                                 is_score_specific_substation,
-                                 color_attrs, label_attrs, direction):
+    def _pick_interesting_bus_id(self, graph: nx.MultiDiGraph, node: int, topo_vect: List[int], isSingleNode: bool,
+                                 is_score_specific_substation: bool,
+                                 color_attrs: Dict[Any, Any], label_attrs: Dict[Any, Any], direction: str) -> int:
         """
         Return the bus id on which to score edges for amont/aval branches.
 
@@ -456,7 +457,7 @@ class AlphaDeesp:  # AKA SOLVER
         neg1 = fabs(sum(x for x in caps_bus1 if x < 0))
         return 1 if neg1 > neg0 else 0
 
-    def _collect_flows_on_bus(self, graph, node, bus_id, topo_vect, label_attrs):
+    def _collect_flows_on_bus(self, graph: nx.MultiDiGraph, node: int, bus_id: int, topo_vect: List[int], label_attrs: Dict[Any, Any]) -> Dict[str, List[float]]:
         """
         Partition in/out flows incident to ``node`` on ``bus_id`` into the
         four (positive, negative) × (in, out) buckets.
@@ -488,8 +489,8 @@ class AlphaDeesp:  # AKA SOLVER
         return {"in_pos": in_pos, "in_neg": in_neg,
                 "out_pos": out_pos, "out_neg": out_neg}
 
-    def _score_amont(self, graph, node, topo_vect, isSingleNode,
-                     is_score_specific_substation, color_attrs, label_attrs):
+    def _score_amont(self, graph: nx.MultiDiGraph, node: int, topo_vect: List[int], isSingleNode: bool,
+                     is_score_specific_substation: bool, color_attrs: Dict[Any, Any], label_attrs: Dict[Any, Any]) -> Any:
         """Score a node that sits in "amont" (upstream) of the constrained path."""
         if self.debug:
             logger.debug("||||||||||||||||||||||||||| node [%s] is in_Amont of constrained_edge", node)
@@ -525,8 +526,8 @@ class AlphaDeesp:  # AKA SOLVER
 
         return final_score
 
-    def _score_aval(self, graph, node, topo_vect, isSingleNode,
-                    is_score_specific_substation, color_attrs, label_attrs):
+    def _score_aval(self, graph: nx.MultiDiGraph, node: int, topo_vect: List[int], isSingleNode: bool,
+                    is_score_specific_substation: bool, color_attrs: Dict[Any, Any], label_attrs: Dict[Any, Any]) -> Any:
         """Score a node that sits in "aval" (downstream) of the constrained path."""
         if self.debug:
             logger.debug("||||||||||||||||||||||||||| node [%s] is in_Aval of constrained_edge", node)
@@ -570,7 +571,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return final_score
 
-    def _score_in_red_loop(self, graph, node, topo_vect, color_attrs, label_attrs):
+    def _score_in_red_loop(self, graph: nx.MultiDiGraph, node: int, topo_vect: List[int], color_attrs: Dict[Any, Any], label_attrs: Dict[Any, Any]) -> Any:
         """
         Score a node that belongs to a red loop path.
 
@@ -609,7 +610,7 @@ class AlphaDeesp:  # AKA SOLVER
         injection = -self.get_prod_conso_sum(node, biggest_bus, topo_vect)
         return np.around(min_pos_in_or_out + injection, decimals=2)
 
-    def _score_not_connected_to_cpath(self, graph, node, topo_vect, label_attrs):
+    def _score_not_connected_to_cpath(self, graph: nx.MultiDiGraph, node: int, topo_vect: List[int], label_attrs: Dict[Any, Any]) -> Any:
         """
         Score a node that is not on the constrained path or any red loop.
         The score is the smaller imbalance between the two candidate busbars.
@@ -648,7 +649,7 @@ class AlphaDeesp:  # AKA SOLVER
 
         return final_score
 
-    def get_prod_conso_sum(self, node, interesting_bus_id, topo_vect):
+    def get_prod_conso_sum(self, node: int, interesting_bus_id: int, topo_vect: List[int]) -> float:
         total = 0
         elements = self.simulator_data["substations_elements"][node]
         for element, bus_id in zip(elements, topo_vect):
@@ -659,7 +660,7 @@ class AlphaDeesp:  # AKA SOLVER
                     total = total + element.value
         return total
 
-    def get_bus_id_from_edge(self, node, edge, topo_vect):
+    def get_bus_id_from_edge(self, node: int, edge: Tuple[Any, Any, Any], topo_vect: List[int]) -> Optional[int]:
         """
         Knowing that topo_vect is applied on given node, returns on which bus_id is connected a given edge
 
@@ -693,7 +694,7 @@ class AlphaDeesp:  # AKA SOLVER
                     else:  # in that case there are parallel edges between the two nodes, so deal with that
                         paralel_edge_counter += 1
 
-    def is_connected_to_cpath(self, all_edges_color_attributes, all_edges_xlabel_attributes, node, edge, isSingleNode):
+    def is_connected_to_cpath(self, all_edges_color_attributes: Dict[Any, Any], all_edges_xlabel_attributes: Dict[Any, Any], node: int, edge: Tuple[Any, Any, Any], isSingleNode: bool) -> bool:
         edge_color = all_edges_color_attributes[edge]
         edge_value = all_edges_xlabel_attributes[edge]
         # if there is a outgoing negative blue or black edge this means we are connected to cpath.
@@ -705,7 +706,7 @@ class AlphaDeesp:  # AKA SOLVER
             logger.debug("######################################################")
         return bool
 
-    def sort_hubs(self, hubs):
+    def sort_hubs(self, hubs: Optional[List[Any]]) -> Optional[pd.DataFrame]:
         # creates a DATAFRAME and sort it, returns the sorted hubs
         # print("================= sort_hubs =================")
         if hubs:
@@ -741,7 +742,7 @@ class AlphaDeesp:  # AKA SOLVER
         # else:
         #   raise ValueError("There are no hubs")
 
-    def identify_routing_buses(self):
+    def identify_routing_buses(self) -> Dict[int, Any]:
         """Categories 1 to 4
         1. Hubs
         2. all nodes that belong to c_path
@@ -769,7 +770,7 @@ class AlphaDeesp:  # AKA SOLVER
             d = {1: category1, 2: set_category2, 3: category3, 4: set_category4}
         return d
 
-    def rank_loop_buses(self, graph, df_initial_flows):
+    def rank_loop_buses(self, graph: nx.MultiDiGraph, df_initial_flows: pd.DataFrame) -> Dict[Any, float]:
         # self.g => overflow graph
         all_edges_color_attributes = nx.get_edge_attributes(graph, "color")  # dict[edge]
         all_edges_xlabel_attributes = nx.get_edge_attributes(graph, "label")
@@ -824,7 +825,7 @@ class AlphaDeesp:  # AKA SOLVER
                         Strength_Bus_dic[bus] = strength_measure
         return Strength_Bus_dic
 
-    def rank_red_loops(self):
+    def rank_red_loops(self) -> None:
         cut_values = []
         cut_sets = []  # contains the edges that ended up having the minimum cut_values
         g_red_DiGraph=self.to_DiGraph(self.g_distribution_graph.g_only_red_components)#self.g_only_red_components)#necessary to be able to compute minimum_cut
@@ -859,7 +860,7 @@ class AlphaDeesp:  # AKA SOLVER
         # print(self.red_loops)
 
     # create weighted digraph from MultiDiGraph
-    def to_DiGraph(self,gM):
+    def to_DiGraph(self, gM: nx.MultiDiGraph) -> nx.DiGraph:
         G = nx.DiGraph()
         for u, v,idx, data in gM.edges(data=True,keys=True):
             w = data['capacity'] if 'capacity' in data else 1.0
@@ -869,18 +870,18 @@ class AlphaDeesp:  # AKA SOLVER
                 G.add_edge(u, v, capacity=w)
         return G
 
-    def compute_meaningful_structures(self):
+    def compute_meaningful_structures(self) -> None:
         self.data["constrained_path"] = self.get_constrained_path()
 
-    def get_adjacency_matrix(self, g):
+    def get_adjacency_matrix(self, g: nx.MultiDiGraph) -> None:
         logger.debug("adjacency matrix full = ")
         for line in nx.generate_adjlist(g):
             logger.debug("%s", line)
 
-    def get_loop_paths(self):
+    def get_loop_paths(self) -> None:
         pass
 
-    def filter_constrained_path(self, path_to_filter):
+    def filter_constrained_path(self, path_to_filter: Any) -> List[Any]:
         """This function gets rid of duplicates, tuples, arrays, and return a single clean ordered array"""
         set_constrained_path = []
         for edge in path_to_filter:
@@ -894,21 +895,21 @@ class AlphaDeesp:  # AKA SOLVER
                         set_constrained_path.append(node)
         return set_constrained_path
 
-    def isAntenna(self):
+    def isAntenna(self) -> None:
         pass
 
-    def write_g(self, g):
+    def write_g(self, g: nx.MultiDiGraph) -> None:
         """This saves file g"""
         nx.write_edgelist(self.g, "./alphaDeesp/tmp/save.graph")
         # print("file saved")
         pass
 
-    def read_g(self):
+    def read_g(self) -> None:
         pass
 
 
 class AlphaDeesp_warmStart(AlphaDeesp):
-    def __init__(self, g, g_distribution_graph,simulator_data=None, debug=False):
+    def __init__(self, g: nx.MultiDiGraph, g_distribution_graph: Any, simulator_data: Optional[Dict[str, Any]] = None, debug: bool = False) -> None:
         # used for postprocessing
         self.bag_of_graphs = {}
         self.debug = debug

--- a/alphaDeesp/core/graphsAndPaths.py
+++ b/alphaDeesp/core/graphsAndPaths.py
@@ -1,5 +1,6 @@
 
 import logging
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 import networkx as nx
@@ -17,7 +18,7 @@ class PowerFlowGraph:
     A coloured graph of current grid state with productions, consumptions and topology
     """
 
-    def __init__(self, topo,lines_cut,layout=None,float_precision="%.2f"):
+    def __init__(self, topo: Dict[str, Any], lines_cut: List[int], layout: Optional[List[Tuple[float, float]]] = None, float_precision: str = "%.2f") -> None:
         """
         Parameters
         ----------
@@ -40,7 +41,7 @@ class PowerFlowGraph:
         self.build_graph()
         #self.g=self.build_powerflow_graph()
 
-    def build_graph(self):
+    def build_graph(self) -> None:
         """This method creates the NetworkX Graph of the grid state"""
         g = nx.MultiDiGraph()
 
@@ -64,7 +65,7 @@ class PowerFlowGraph:
         #return g
         self.g=g
 
-    def build_nodes(self,g, are_prods, are_loads, prods_values, loads_values,debug=False):
+    def build_nodes(self, g: nx.MultiDiGraph, are_prods: Any, are_loads: Any, prods_values: Any, loads_values: Any, debug: bool = False) -> None:
         """
         Create nodes in graph for current grid state
 
@@ -109,7 +110,7 @@ class PowerFlowGraph:
                            fillcolor="#ffffed")  # white color
             i += 1
 
-    def build_edges(self,g, idx_or, idx_ex, edge_weights):
+    def build_edges(self, g: nx.MultiDiGraph, idx_or: Any, idx_ex: Any, edge_weights: Any) -> None:
 
         """
         Create edges in graph for current grid state
@@ -159,7 +160,7 @@ class PowerFlowGraph:
                            penwidth=max(float(self.float_precision % penwidth),min_penwidth))
 
 
-    def get_graph(self):
+    def get_graph(self) -> nx.MultiDiGraph:
         """
         Returns the NetworkX graph representing the current state of the power flow.
 
@@ -170,7 +171,7 @@ class PowerFlowGraph:
         """
         return self.g
 
-    def set_voltage_level_color(self, voltage_levels_dict, voltage_colors=default_voltage_colors):
+    def set_voltage_level_color(self, voltage_levels_dict: Dict[Any, Any], voltage_colors: Dict[Any, str] = default_voltage_colors) -> None:
         """
         Sets the voltage level color for each node in the graph based on the provided voltage levels dictionary.
 
@@ -189,7 +190,7 @@ class PowerFlowGraph:
 
         nx.set_node_attributes(self.g, voltage_levels_colors_dict, "color")
 
-    def set_electrical_node_number(self, nodal_number_dict):
+    def set_electrical_node_number(self, nodal_number_dict: Dict[Any, Any]) -> None:
         """
         Sets the electrical node number for each node in the graph based on the provided nodal number dictionary.
 
@@ -206,7 +207,7 @@ class PowerFlowGraph:
 
         nx.set_node_attributes(self.g, peripheries_dict, "peripheries")
 
-    def plot(self, save_folder, name, state="before", sim=None):
+    def plot(self, save_folder: str, name: str, state: str = "before", sim: Optional[Any] = None) -> None:
         """
         Plots the graph using the Printer class.
 
@@ -245,7 +246,7 @@ class OverFlowGraph(PowerFlowGraph):
     A coloured graph of grid overflow redispatch, displaying the delta flows before and after disconnecting the overloaded lines
     """
 
-    def __init__(self, topo,lines_to_cut,df_overflow,layout=None,float_precision="%.2f"):
+    def __init__(self, topo: Dict[str, Any], lines_to_cut: List[int], df_overflow: pd.DataFrame, layout: Optional[List[Tuple[float, float]]] = None, float_precision: str = "%.2f") -> None:
         """
         Parameters
         ----------
@@ -269,7 +270,7 @@ class OverFlowGraph(PowerFlowGraph):
         self.df = df_overflow
         super().__init__(topo, lines_to_cut,layout,float_precision)
 
-    def build_graph(self):
+    def build_graph(self) -> None:
         """This method creates the NetworkX Graph of the overflow redispatch """
         g = nx.MultiDiGraph()
         self.build_nodes(g, self.topo["nodes"]["are_prods"], self.topo["nodes"]["are_loads"],
@@ -284,7 +285,7 @@ class OverFlowGraph(PowerFlowGraph):
         self.g=g
         #self.add_double_edges_null_redispatch()
 
-    def build_edges_from_df(self, g, lines_to_cut):
+    def build_edges_from_df(self, g: nx.MultiDiGraph, lines_to_cut: List[int]) -> None:
         """
         Create edges in graph for overflow redispatch
 
@@ -331,7 +332,7 @@ class OverFlowGraph(PowerFlowGraph):
             i += 1
         #nx.set_edge_attributes(g, {e:self.df["line_name"][i] for i,e in enumerate(g.edges)}, name="name")
 
-    def keep_overloads_components(self):
+    def keep_overloads_components(self) -> None:
         """
         Filter the graph to only keep components that contain overloaded (black) edges.
 
@@ -362,7 +363,7 @@ class OverFlowGraph(PowerFlowGraph):
                         if self.g[u][v][key].get("color") != "gray":
                             self.g[u][v][key]["color"] = "gray"
 
-    def consolidate_constrained_path(self, constrained_path_nodes_amont,constrained_path_nodes_aval,constrained_path_edges,ignore_null_edges=True):#hub_sources,hub_targets):
+    def consolidate_constrained_path(self, constrained_path_nodes_amont: List[Any], constrained_path_nodes_aval: List[Any], constrained_path_edges: List[Any], ignore_null_edges: bool = True) -> None:  # hub_sources,hub_targets):
         """
         Consolidate constrained blue path for some edges that were discarded with lower values but are actually on the path
         knowing the hubs in the SuscturedOverflowGraph
@@ -493,7 +494,7 @@ class OverFlowGraph(PowerFlowGraph):
 #
         #print("ok")
 
-    def reverse_edges(self, edge_path_names,target_color):
+    def reverse_edges(self, edge_path_names: List[str], target_color: str) -> None:
 
         graph_adge_names = nx.get_edge_attributes(self.g, 'name')
         edges_path=[edge for edge, name in graph_adge_names.items() if name in edge_path_names]
@@ -519,7 +520,7 @@ class OverFlowGraph(PowerFlowGraph):
         self.g.add_edges_from([(edge[1], edge[0], edge[2]) for edge in path_subgraph_to_reverse.edges(data=True)])
         self.g.remove_edges_from(edges_to_reverse)
 
-    def reverse_blue_edges_in_looppaths(self, constrained_path):
+    def reverse_blue_edges_in_looppaths(self, constrained_path: List[Any]) -> None:
         """
         Reverse blue edges that are not on the constrained paths, and that should be regarded as edges on which we are pushing
         the flows
@@ -558,7 +559,7 @@ class OverFlowGraph(PowerFlowGraph):
         self.g.add_edges_from([(edge[1], edge[0], edge[2]) for edge in g_without_pos_edges.edges(data=True)])
         self.g.remove_edges_from(g_without_pos_edges.edges)
 
-    def consolidate_loop_path(self, hub_sources,hub_targets,ignore_null_edges=True):
+    def consolidate_loop_path(self, hub_sources: Iterable[Any], hub_targets: Iterable[Any], ignore_null_edges: bool = True) -> None:
         """
         Consolidate constrained red path for some edges that were discarded with lower values but are actually on the path
         knowing the hubs in the SuscturedOverflowGraph
@@ -598,7 +599,7 @@ class OverFlowGraph(PowerFlowGraph):
         edge_attribues_to_set = {edge: {"color": "coral"} for i,edge in enumerate(g_without_blue_edges.edges) if edge in all_edges_to_recolor and current_colors[edge]=="gray"}
         nx.set_edge_attributes(self.g, edge_attribues_to_set)
 
-    def set_hubs_shape(self, hubs,shape_hub="circle"):
+    def set_hubs_shape(self, hubs: Iterable[Any], shape_hub: str = "circle") -> None:
         """
         Distinguish the shape of "hub" nodes to make them more visible
 
@@ -617,7 +618,7 @@ class OverFlowGraph(PowerFlowGraph):
 
         nx.set_node_attributes(self.g, dict_shapes, "shape")
 
-    def highlight_swapped_flows(self, lines_swapped):
+    def highlight_swapped_flows(self, lines_swapped: List[Any]) -> None:
         """
         Highlight lines with "tappered" style on edge that have seen their flows swapped in the overflow graph to be aware of that
 
@@ -637,7 +638,7 @@ class OverFlowGraph(PowerFlowGraph):
         nx.set_edge_attributes(self.g, edge_dirs, "dir")
         nx.set_edge_attributes(self.g, edge_tails, "arrowtail")
 
-    def highlight_significant_line_loading(self, dict_line_loading):
+    def highlight_significant_line_loading(self, dict_line_loading: Dict[Any, Any]) -> None:
         """
         Highlight lines that could get overloaded and should be monitored. Edge label is augmented with change in loading rate
         before and after the constrained line cut
@@ -680,7 +681,7 @@ class OverFlowGraph(PowerFlowGraph):
         nx.set_edge_attributes(self.g, label_font_color, "fontcolor")
         nx.set_edge_attributes(self.g, edge_colors, "color")
 
-    def plot(self,layout,rescale_factor=None,allow_overlap=True,fontsize=None,node_thickness=3,save_folder="",without_gray_edges=False):
+    def plot(self, layout: Optional[List[Any]], rescale_factor: Optional[float] = None, allow_overlap: bool = True, fontsize: Optional[int] = None, node_thickness: int = 3, save_folder: str = "", without_gray_edges: bool = False) -> Any:
         printer=Printer(save_folder)
         g=self.g
 
@@ -701,7 +702,7 @@ class OverFlowGraph(PowerFlowGraph):
             printer.display_geo(g, layout,rescale_factor=rescale_factor,fontsize=fontsize,node_thickness=node_thickness, name="g_overflow_print")
             return None
 
-    def consolidate_graph(self, structured_graph,non_connected_lines_to_ignore=[],no_desambiguation=False):
+    def consolidate_graph(self, structured_graph: Any, non_connected_lines_to_ignore: List[Any] = [], no_desambiguation: bool = False) -> None:
         """
         Consolidate overflow graph knwoing structural elements from SuscturedOverflowGraph
 
@@ -764,7 +765,7 @@ class OverFlowGraph(PowerFlowGraph):
         #add back removed edges
         self.g.add_edges_from(edges_to_remove_data)
 
-    def identify_ambiguous_paths(self, structured_graph):
+    def identify_ambiguous_paths(self, structured_graph: Any) -> Tuple[List[Any], List[Any]]:
         """
         Identify ambiguous paths in the structured graph.
 
@@ -819,7 +820,7 @@ class OverFlowGraph(PowerFlowGraph):
 
         return ambiguous_edge_paths, ambiguous_node_paths
 
-    def desambiguation_type_path(self, ambiguous_node_path, structured_graph):
+    def desambiguation_type_path(self, ambiguous_node_path: Iterable[Any], structured_graph: Any) -> str:
         """
         Desambiguates the type of path for ambiguous nodes based on the structured graph.
 
@@ -876,12 +877,12 @@ class OverFlowGraph(PowerFlowGraph):
             # it is classified as a loop path
             return "loop_path"
 
-    def rename_nodes(self,mapping):
+    def rename_nodes(self, mapping: Dict[Any, Any]) -> None:
         self.g = nx.relabel_nodes(self.g, mapping, copy=True)
         self.df["idx_or"]=[mapping[idx_or] for idx_or in self.df["idx_or"]]
         self.df["idx_ex"] = [mapping[idx_or] for idx_or in self.df["idx_ex"]]
 
-    def _setup_null_flow_styles(self, non_connected_lines, non_reconnectable_lines):
+    def _setup_null_flow_styles(self, non_connected_lines: List[Any], non_reconnectable_lines: List[Any]) -> List[Any]:
         """
         One-time setup of edge styles and directions for non-connected/non-reconnectable lines.
         Returns pre-computed edge sets for reuse across target_path iterations.
@@ -909,7 +910,7 @@ class OverFlowGraph(PowerFlowGraph):
 
         return non_connected_lines
 
-    def add_relevant_null_flow_lines_all_paths(self, structured_graph, non_connected_lines,non_reconnectable_lines=[]):
+    def add_relevant_null_flow_lines_all_paths(self, structured_graph: Any, non_connected_lines: List[Any], non_reconnectable_lines: List[Any] = []) -> None:
         """
         Make edges bi-directionnal when flow redispatch value is null
 
@@ -950,11 +951,11 @@ class OverFlowGraph(PowerFlowGraph):
 
 
 
-    def add_relevant_null_flow_lines(self, structured_graph, non_connected_lines,
-                                     non_reconnectable_lines=[], target_path="blue_to_red",
-                                     depth_reconnectable_edges_search=2,
-                                     max_null_flow_path_length=7,
-                                     _skip_style_setup=False, _structural_info=None):
+    def add_relevant_null_flow_lines(self, structured_graph: Any, non_connected_lines: List[Any],
+                                     non_reconnectable_lines: List[Any] = [], target_path: str = "blue_to_red",
+                                     depth_reconnectable_edges_search: int = 2,
+                                     max_null_flow_path_length: int = 7,
+                                     _skip_style_setup: bool = False, _structural_info: Optional[Dict[str, Any]] = None) -> None:
         """
         Make edges bi-directional when flow redispatch is null, recolor the
         relevant ones that could be of interest for analyzing or solving the
@@ -1026,7 +1027,7 @@ class OverFlowGraph(PowerFlowGraph):
     # Helpers for add_relevant_null_flow_lines
     # ------------------------------------------------------------------
 
-    def _prepare_null_flow_edge_sets(self, non_connected_lines, non_reconnectable_lines):
+    def _prepare_null_flow_edge_sets(self, non_connected_lines: List[Any], non_reconnectable_lines: List[Any]) -> Dict[str, Any]:
         """
         Compute the input edge sets used by :meth:`add_relevant_null_flow_lines`:
         the plain line-name sets, plus ``edges_non_connected_lines_to_consider``
@@ -1064,7 +1065,7 @@ class OverFlowGraph(PowerFlowGraph):
             "edges_non_connected_lines_to_consider": edges_non_connected_lines_to_consider,
         }
 
-    def _build_gray_components(self):
+    def _build_gray_components(self) -> List[Any]:
         """
         Build the list of weakly connected components consisting only of
         "gray" edges (i.e. non-coral/blue/black). Components are returned
@@ -1088,7 +1089,7 @@ class OverFlowGraph(PowerFlowGraph):
         ]
 
     @staticmethod
-    def _structural_info_for_null_flow(structured_graph):
+    def _structural_info_for_null_flow(structured_graph: Any) -> Dict[str, Any]:
         """Extract the red/amont/aval node sets once per call."""
         node_red_paths = []
         if structured_graph.red_loops.Path.shape[0] != 0:
@@ -1099,12 +1100,12 @@ class OverFlowGraph(PowerFlowGraph):
             "node_aval_constrained_path": structured_graph.constrained_path.n_aval(),
         }
 
-    def _detect_edges_for_target_path(self, gray_components, target_path, structural_info,
-                                      edges_non_connected_lines_to_consider,
-                                      edges_non_connected_lines,
-                                      edges_non_reconnectable_lines,
-                                      depth_reconnectable_edges_search,
-                                      max_null_flow_path_length):
+    def _detect_edges_for_target_path(self, gray_components: List[Any], target_path: str, structural_info: Dict[str, Any],
+                                      edges_non_connected_lines_to_consider: Set[Any],
+                                      edges_non_connected_lines: Set[Any],
+                                      edges_non_reconnectable_lines: Set[Any],
+                                      depth_reconnectable_edges_search: int,
+                                      max_null_flow_path_length: int) -> Tuple[Set[Any], Set[Any]]:
         """
         Per-component dispatch to :meth:`detect_edges_to_keep` based on the
         chosen ``target_path`` strategy. Each strategy picks a different
@@ -1176,8 +1177,8 @@ class OverFlowGraph(PowerFlowGraph):
 
         return edges_to_keep, edges_non_reconnectable
 
-    def _apply_null_flow_recoloring(self, target_path, edges_to_keep, edges_non_reconnectable,
-                                    edges_to_double, edges_double_added):
+    def _apply_null_flow_recoloring(self, target_path: str, edges_to_keep: Set[Any], edges_non_reconnectable: Set[Any],
+                                    edges_to_double: Dict[Any, Any], edges_double_added: Dict[Any, Any]) -> None:
         """
         Paint the detected edges and roll back the double-edges that were
         not used. Blue/red colours follow the ``target_path`` strategy; for
@@ -1216,9 +1217,9 @@ class OverFlowGraph(PowerFlowGraph):
         self.g = remove_unused_added_double_edge(
             self.g, edges_to_keep, edges_to_double, edges_double_added)
 
-    def detect_edges_to_keep(self, g_c, source_nodes, target_nodes, edges_of_interest,
-                             non_reconnectable_edges=[], depth_edges_search=2,
-                             max_null_flow_path_length=7):
+    def detect_edges_to_keep(self, g_c: nx.MultiDiGraph, source_nodes: Iterable[Any], target_nodes: Iterable[Any], edges_of_interest: Set[Any],
+                             non_reconnectable_edges: List[Any] = [], depth_edges_search: int = 2,
+                             max_null_flow_path_length: int = 7) -> Tuple[Set[Any], Set[Any]]:
         """
         Detect edges in ``edges_of_interest`` that lie on a short path between
         ``source_nodes`` and ``target_nodes`` inside the subgraph ``g_c``.
@@ -1255,8 +1256,8 @@ class OverFlowGraph(PowerFlowGraph):
     # Helpers for detect_edges_to_keep
     # ------------------------------------------------------------------
 
-    def _prepare_detect_edges_inputs(self, g_c, source_nodes, target_nodes, edges_of_interest,
-                                     non_reconnectable_edges, depth_edges_search):
+    def _prepare_detect_edges_inputs(self, g_c: nx.MultiDiGraph, source_nodes: Iterable[Any], target_nodes: Iterable[Any], edges_of_interest: Set[Any],
+                                     non_reconnectable_edges: List[Any], depth_edges_search: int) -> Optional[Dict[str, Any]]:
         """
         Run the up-front bookkeeping shared by every branch of
         :meth:`detect_edges_to_keep`:
@@ -1328,7 +1329,7 @@ class OverFlowGraph(PowerFlowGraph):
             "any_target_has_interest": any_target_has_interest,
         }
 
-    def _compute_sssp_paths(self, g_c, prepared, edges_of_interest):
+    def _compute_sssp_paths(self, g_c: nx.MultiDiGraph, prepared: Dict[str, Any], edges_of_interest: Set[Any]) -> Dict[Any, Any]:
         """
         Run single-source Dijkstra once per source node with a weight function
         that massively favours low-capacity edges and gently promotes edges
@@ -1366,7 +1367,7 @@ class OverFlowGraph(PowerFlowGraph):
                 sssp_paths_cache[source_node] = {}
         return sssp_paths_cache
 
-    def _collect_paths_of_interest(self, g_c, prepared, sssp_paths_cache, max_null_flow_path_length):
+    def _collect_paths_of_interest(self, g_c: nx.MultiDiGraph, prepared: Dict[str, Any], sssp_paths_cache: Dict[Any, Any], max_null_flow_path_length: int) -> List[Any]:
         """
         Walk the (source, target) product and materialise the paths whose
         node-count is within ``max_null_flow_path_length`` and which actually
@@ -1406,7 +1407,7 @@ class OverFlowGraph(PowerFlowGraph):
         paths_of_interest.sort(key=len)
         return paths_of_interest
 
-    def _classify_paths_by_reconnectability(self, prepared, paths_of_interest):
+    def _classify_paths_by_reconnectability(self, prepared: Dict[str, Any], paths_of_interest: List[Any]) -> Tuple[Set[Any], Set[Any]]:
         """
         Greedy dedupe over the sorted ``paths_of_interest``: each edge name
         is attributed to the *first* (shortest) path that uses it, and the
@@ -1439,7 +1440,7 @@ class OverFlowGraph(PowerFlowGraph):
 
         return set(edges_to_keep_reconnectable), set(edges_to_keep_non_reconnectable)
 
-    def collapse_red_loops(self):
+    def collapse_red_loops(self) -> None:
         """
         Collapse nodes that are purely part of "red loops" (coral-only edges) into point shapes.
 
@@ -1498,7 +1499,7 @@ class ConstrainedPath:
     Hence flows should be pushed on other path to relieve the overloads.
     """
 
-    def __init__(self, amont_edges, constrained_edge, aval_edges):
+    def __init__(self, amont_edges: List[Any], constrained_edge: Any, aval_edges: List[Any]) -> None:
         logger.debug("Constrained path created")
         self.amont_edges = amont_edges #lines which flow goes into the overloaded lines
         self.constrained_edge = constrained_edge #overloaded lines
@@ -1508,19 +1509,19 @@ class ConstrainedPath:
         """Returns a list of nodes that are in "amont" """
         return from_edges_get_nodes(self.amont_edges, "amont", self.constrained_edge)
 
-    def n_aval(self):
+    def n_aval(self) -> List[Any]:
         """Returns a list of nodes that are in "aval" """
         return from_edges_get_nodes(self.aval_edges, "aval", self.constrained_edge)
 
-    def e_amont(self):
+    def e_amont(self) -> List[Any]:
         """Returns a list of edges that are in "amont" """
         return self.amont_edges
 
-    def e_aval(self):
+    def e_aval(self) -> List[Any]:
         """Returns a list of edges that are in "aval" """
         return self.aval_edges
 
-    def filter_constrained_path_for_nodes(self):
+    def filter_constrained_path_for_nodes(self) -> List[Any]:
         """
         This filters the constrained_path_lists and creates a uniq ordered list that represents the constrained_path
 
@@ -1547,10 +1548,10 @@ class ConstrainedPath:
 
         return set_constrained_path
 
-    def full_n_constrained_path(self):
+    def full_n_constrained_path(self) -> List[Any]:
         return self.filter_constrained_path_for_nodes()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "################################################################\n" \
                "ConstrainedPath = %s \nDetails: (amont: %s, constrained_edge: %s, aval: %s)\n" \
                "################################################################" % (
@@ -1560,7 +1561,7 @@ class Structured_Overload_Distribution_Graph:
     """
     Staring from a raw overload distribution graph with color edges, this class identifies the underlying path structure in terms of constrained path, loop paths and hub nodes
     """
-    def __init__(self,g,possible_hubs=None):
+    def __init__(self, g: nx.MultiDiGraph, possible_hubs: Optional[List[Any]] = None) -> None:
         """
         Parameters
         ----------
@@ -1588,7 +1589,7 @@ class Structured_Overload_Distribution_Graph:
         self.red_loops = self.find_loops() #parallel path to the constrained path on which flow can be rerouted
         self.hubs = self.find_hubs() #specific nodes at substations connecting loop paths to constrained path. This is where flow can be most easily rerouted
 
-    def get_amont_blue_edges(self, g, node):
+    def get_amont_blue_edges(self, g: nx.MultiDiGraph, node: Any) -> List[Any]:
         """
         From a given node, get blue edges (with negative overflow redispatch) that are above this node
 
@@ -1614,7 +1615,7 @@ class Structured_Overload_Distribution_Graph:
                 res.append((e[0], e[1],e[2]))
         return res
 
-    def get_aval_blue_edges(self, g, node):
+    def get_aval_blue_edges(self, g: nx.MultiDiGraph, node: Any) -> List[Any]:
         """
         From a given node, get blue edges (with negative overflow redispatch) that are after this node
 
@@ -1643,7 +1644,7 @@ class Structured_Overload_Distribution_Graph:
         return res
 
 
-    def find_hubs(self):
+    def find_hubs(self) -> List[Any]:
         """
         "A hub (carrefour_electrique) has a constrained_path and positiv reports"
 
@@ -1681,10 +1682,10 @@ class Structured_Overload_Distribution_Graph:
         # print("get_hubs = ", hubs)
         return hubs
 
-    def get_hubs(self):
+    def get_hubs(self) -> List[Any]:
         return self.hubs
 
-    def find_loops(self):
+    def find_loops(self) -> pd.DataFrame:
 
         """This function returns all parallel paths. After discussing with Antoine, start with the most "en Aval" node,
         and walk in reverse for loops and parallel path returns a dict with all data
@@ -1765,10 +1766,10 @@ class Structured_Overload_Distribution_Graph:
 
         return pd.DataFrame(data_for_df)
 
-    def get_loops(self):
+    def get_loops(self) -> pd.DataFrame:
         return self.red_loops
 
-    def find_constrained_path(self):
+    def find_constrained_path(self) -> "ConstrainedPath":
         """Find and return the constrained path
 
          Returns
@@ -1787,10 +1788,10 @@ class Structured_Overload_Distribution_Graph:
 
         return ConstrainedPath(amont_edges,constrained_edge,aval_edges)
 
-    def get_constrained_path(self):
+    def get_constrained_path(self) -> "ConstrainedPath":
         return self.constrained_path
 
-    def get_constrained_edges_nodes(self):
+    def get_constrained_edges_nodes(self) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
         """
         This function identifies the constrained path within the distribution graph.
 
@@ -1827,7 +1828,7 @@ class Structured_Overload_Distribution_Graph:
 
         return list(set(edges_constrained_path)), nodes_constrained_path, other_blue_edges, other_blue_nodes
 
-    def get_dispatch_edges_nodes(self,only_loop_paths=True):
+    def get_dispatch_edges_nodes(self, only_loop_paths: bool = True) -> Tuple[List[Any], List[Any]]:
         """
         This function identifies the dispatch path within the distribution graph.
 
@@ -1855,7 +1856,7 @@ class Structured_Overload_Distribution_Graph:
         return lines_redispatch, list_nodes_dispatch_path
 
 
-def from_edges_get_nodes(edges, amont_or_aval: str, constrained_edge):
+def from_edges_get_nodes(edges: Iterable[Any], amont_or_aval: str, constrained_edge: Any) -> List[Any]:
     """edges is a list of tuples"""
     if edges:
         nodes = []
@@ -1871,7 +1872,7 @@ def from_edges_get_nodes(edges, amont_or_aval: str, constrained_edge):
     else:
         raise ValueError("Error in function from_edges_get_nodes")
 
-def delete_color_edges(_g, edge_color):
+def delete_color_edges(_g: nx.MultiDiGraph, edge_color: str) -> nx.MultiDiGraph:
     """
     Returns a copy of a graph without edges of a given color. Gray for instance, with values below a threshold of significance
 
@@ -1909,7 +1910,7 @@ def delete_color_edges(_g, edge_color):
         g.remove_nodes_from(list(nx.isolates(g)))
     return g
 
-def nodepath_to_edgepath(G, node_path, with_keys=False):
+def nodepath_to_edgepath(G: Any, node_path: List[Any], with_keys: bool = False) -> List[Any]:
     """Convert a list of nodes into a list of edges for Graph/MultiGraph."""
     edges = []
     for u, v in zip(node_path[:-1], node_path[1:]):
@@ -1923,7 +1924,7 @@ def nodepath_to_edgepath(G, node_path, with_keys=False):
             edges.append((u, v))
     return edges
 
-def incident_edges(G, node, data=True, keys=False):
+def incident_edges(G: Any, node: Any, data: bool = True, keys: bool = False) -> List[Any]:
     if keys and G.is_multigraph():
         out_e = G.out_edges(node, keys=True, data=data)
         in_e  = G.in_edges(node, keys=True, data=data)
@@ -1932,7 +1933,7 @@ def incident_edges(G, node, data=True, keys=False):
         in_e  = G.in_edges(node, data=data)
     return list(out_e) + list(in_e)
 
-def all_simple_edge_paths_multi(G, sources, targets, cutoff=None):
+def all_simple_edge_paths_multi(G: Any, sources: Iterable[Any], targets: Iterable[Any], cutoff: Optional[int] = None) -> Any:
     """
     Yield all simple edge paths between multiple sources and targets.
 
@@ -1960,7 +1961,7 @@ def all_simple_edge_paths_multi(G, sources, targets, cutoff=None):
                 except nx.NetworkXNoPath:
                     continue
 
-def remove_unused_added_double_edge(g, edges_to_keep, edges_to_double, edges_double_added):
+def remove_unused_added_double_edge(g: nx.MultiDiGraph, edges_to_keep: Set[Any], edges_to_double: Dict[Any, Any], edges_double_added: Dict[Any, Any]) -> nx.MultiDiGraph:
 
     """
     Make edges bi-directionnal when flow redispatch value is null
@@ -2005,7 +2006,7 @@ def remove_unused_added_double_edge(g, edges_to_keep, edges_to_double, edges_dou
 
     return g
 
-def add_double_edges_null_redispatch(g,color_init="gray",only_no_dir=False):
+def add_double_edges_null_redispatch(g: nx.MultiDiGraph, color_init: str = "gray", only_no_dir: bool = False) -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
     """
     Make edges bi-directionnal when flow redispatch value is null
 
@@ -2046,7 +2047,7 @@ def add_double_edges_null_redispatch(g,color_init="gray",only_no_dir=False):
 
 
 
-def find_multidigraph_edges_by_name(G, source_node, target_names, depth=2, name_attr="name"):
+def find_multidigraph_edges_by_name(G: nx.MultiDiGraph, source_node: Any, target_names: Iterable[Any], depth: int = 2, name_attr: str = "name") -> List[Any]:
     """
     Traverses the MultiDiGraph using BFS up to 'depth'.
     For every connection (u, v) traversed, checks ALL parallel edges
@@ -2076,7 +2077,7 @@ def find_multidigraph_edges_by_name(G, source_node, target_names, depth=2, name_
     return found_edges
 
 
-def shortest_path_min_weight_then_hops(G, source, target, mandatory_edge, weight_attr="weight"):
+def shortest_path_min_weight_then_hops(G: Any, source: Any, target: Any, mandatory_edge: Tuple[Any, ...], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
     """
     Finds the path that:
     1. Passes through 'mandatory_edge'
@@ -2139,7 +2140,7 @@ def shortest_path_min_weight_then_hops(G, source, target, mandatory_edge, weight
         return None, float('inf')
 
 
-def shortest_path_mandatory_and_promoted(G, source, target, mandatory_edge, promoted_edges, weight_attr="weight"):
+def shortest_path_mandatory_and_promoted(G: Any, source: Any, target: Any, mandatory_edge: Tuple[Any, ...], promoted_edges: Iterable[Any], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
     """
     Finds a path that:
     1. MUST pass through 'mandatory_edge'.
@@ -2224,7 +2225,7 @@ def shortest_path_mandatory_and_promoted(G, source, target, mandatory_edge, prom
         return None, float('inf')
 
 
-def shortest_path_with_promoted_edges(G, source, target, promoted_edges, weight_attr="weight"):
+def shortest_path_with_promoted_edges(G: Any, source: Any, target: Any, promoted_edges: Iterable[Any], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
     """
     Finds a path from source to target that:
     1. Minimizes Total Weight (Primary - strict dominance)

--- a/alphaDeesp/core/grid2op/Grid2opSimulation.py
+++ b/alphaDeesp/core/grid2op/Grid2opSimulation.py
@@ -8,6 +8,7 @@
 
 import ast
 import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -16,7 +17,7 @@ import networkx as nx
 
 from grid2op.PlotGrid import PlotMatplot
 
-from alphaDeesp.core.simulation import Simulation
+from alphaDeesp.core.simulation import Simulation, SubstationElement
 from alphaDeesp.core.network import Network
 from alphaDeesp.core.elements import OriginLine, Consumption, Production, ExtremityLine
 from alphaDeesp.core.printer import Printer
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class Grid2opSimulation(Simulation):
-    def compute_layout(self):
+    def compute_layout(self) -> List[Tuple[float, float]]:
         try:
             layout = self.param_options['CustomLayout']
             # Conversion from string to list
@@ -53,10 +54,23 @@ class Grid2opSimulation(Simulation):
         logger.warning("No CustomLayout has been given in config.ini and no grid_layout has been found in Grid2op data. Default layout is set and might cause plotting errors: %s", layout)
         return layout
 
-    def get_layout(self):
+    def get_layout(self) -> List[Tuple[float, float]]:
         return self.layout
 
-    def __init__(self, obs, action_space, observation_space, param_options=None, debug=False, ltc=None, other_ltc=None, plot=False, plot_folder=None, reward_type=None, simu_step=0):
+    def __init__(
+        self,
+        obs: Any,
+        action_space: Any,
+        observation_space: Any,
+        param_options: Optional[Dict[str, Any]] = None,
+        debug: bool = False,
+        ltc: Optional[List[int]] = None,
+        other_ltc: Optional[List[int]] = None,
+        plot: bool = False,
+        plot_folder: Optional[str] = None,
+        reward_type: Optional[str] = None,
+        simu_step: int = 0,
+    ) -> None:
         super().__init__()
 
         # Get Grid2op objects
@@ -105,10 +119,10 @@ class Grid2opSimulation(Simulation):
         self.load()
         self.save_bag = []
 
-    def load(self):
+    def load(self) -> None:
         self.load_from_observation(self.obs, self.ltc+self.other_ltc)
 
-    def load_from_observation(self, obs, linesToDisconnect):
+    def load_from_observation(self, obs: Any, linesToDisconnect: List[int]) -> None:
         #self.obs = obs
         self.topo = self.extract_topo_from_obs(obs)
         self.topo_linecut = None
@@ -118,21 +132,21 @@ class Grid2opSimulation(Simulation):
         self.substations_elements = {}
         self.create_and_fill_internal_structures(obs, self.df)
 
-    def set_simu_step(self,simu_step):
+    def set_simu_step(self, simu_step: int) -> None:
         self.simu_step=simu_step
 
-    def get_substation_elements(self):
+    def get_substation_elements(self) -> Dict[int, List[SubstationElement]]:
         return self.substations_elements
 
-    def get_substation_in_cooldown(self):
+    def get_substation_in_cooldown(self) -> List[int]:
         return [i for i in range(self.obs.n_sub) if (self.obs.time_before_cooldown_sub[i]>=1)]
 
-    def get_reference_topovec_sub(self,sub):
+    def get_reference_topovec_sub(self, sub: int) -> List[int]:
         nelements=self.obs.sub_info[sub]
         topovec=[0 for i in range(nelements)]
         return topovec
 
-    def get_overload_disconnection_topovec_subor(self,l):
+    def get_overload_disconnection_topovec_subor(self, l: int) -> Tuple[int, List[int]]:
         sub_or=self.obs.line_or_to_subid[l]
         position_at_sub=self.obs.line_or_to_sub_pos[l]
         current_topo_vec=self.obs.state_of(substation_id=sub_or)['topo_vect']
@@ -141,19 +155,19 @@ class Grid2opSimulation(Simulation):
         new_topo_vec[position_at_sub]=-1#to get line disconnection
         return sub_or,new_topo_vec
 
-    def get_substation_to_node_mapping(self):
+    def get_substation_to_node_mapping(self) -> Optional[Dict[int, Any]]:
         pass
 
-    def get_internal_to_external_mapping(self):
+    def get_internal_to_external_mapping(self) -> Dict[int, int]:
         return self.internal_to_external_mapping
 
     @staticmethod
-    def merge_two_dicts(x, y):
+    def merge_two_dicts(x: Dict[Any, Any], y: Dict[Any, Any]) -> Dict[Any, Any]:
         z = x.copy()   # start with x's keys and values
         z.update(y)    # modifies z with y's keys and values & returns None
         return z
 
-    def get_action_from_topo(self, substation_id, new_conf, obs):
+    def get_action_from_topo(self, substation_id: int, new_conf: Any, obs: Any) -> Any:
         final_dict = {}
         i = 0
         objects = obs.get_obj_connect_to(substation_id=substation_id)
@@ -180,7 +194,7 @@ class Grid2opSimulation(Simulation):
         # print(final_dict)
         return self.action_space({"set_bus": final_dict})
 
-    def compute_new_network_changes(self, ranked_combinations):
+    def compute_new_network_changes(self, ranked_combinations: List[pd.DataFrame]) -> Tuple[pd.DataFrame, List[Any]]:
         """
         This function takes a dataframe ranked_combinations,
         For each combination it computes a simulation step in Grid2op by following the given combinations
@@ -253,7 +267,18 @@ class Grid2opSimulation(Simulation):
             actions = [self.action_space()]
         return end_result_dataframe, actions
 
-    def compute_one_network_change_score_data(self, obs,virtual_obs,done,info,new_conf,internal_target_node,alphaDeesp_Internal_topo,new_conf_grid2op,score_topo):
+    def compute_one_network_change_score_data(
+        self,
+        obs: Any,
+        virtual_obs: Any,
+        done: bool,
+        info: Dict[str, Any],
+        new_conf: Any,
+        internal_target_node: int,
+        alphaDeesp_Internal_topo: Any,
+        new_conf_grid2op: Any,
+        score_topo: int,
+    ) -> List[Any]:
         # Same as in Pypownet, this is not what we would want though, as we do the work for only one ltc
         only_line = self.ltc[0]
         line_state_before = obs.state_of(line_id=only_line)
@@ -320,7 +345,11 @@ class Grid2opSimulation(Simulation):
         return score_data
 
     @staticmethod
-    def create_boolean_array_of_worsened_line_ids(old_obs, new_obs,nb_timestep_cooldown_line_param):
+    def create_boolean_array_of_worsened_line_ids(
+        old_obs: Any,
+        new_obs: Any,
+        nb_timestep_cooldown_line_param: int,
+    ) -> List[int]:
         res = []
         n_lines=len(new_obs.rho)
 
@@ -345,7 +374,7 @@ class Grid2opSimulation(Simulation):
 
     import numpy as np
 
-    def create_and_fill_internal_structures(self, obs, df):
+    def create_and_fill_internal_structures(self, obs: Any, df: pd.DataFrame) -> None:
         """
         Version optimisée CORRECTIVE.
         Respecte l'ordre strict : [Gens, Loads, Lines_OR, Lines_EX] pour correspondre
@@ -432,7 +461,7 @@ class Grid2opSimulation(Simulation):
         self.substations_elements = dict(enumerate(sub_elements_buckets))
 
     @staticmethod
-    def extract_topo_from_obs(obs):
+    def extract_topo_from_obs(obs: Any) -> Dict[str, Any]:
         """This function, takes an obs an returns a dict with all topology information"""
         d = {
             "edges": {},
@@ -473,7 +502,7 @@ class Grid2opSimulation(Simulation):
         #         print(d[key][key2])
         return d
 
-    def cut_lines_and_recomputes_flows(self, ids: list):
+    def cut_lines_and_recomputes_flows(self, ids: List[int]) -> Any:
         """This functions cuts lines: [ids], simulates and returns new line flows"""
 
         # First, set parameter to avoid disconnection
@@ -509,7 +538,7 @@ class Grid2opSimulation(Simulation):
 
         return new_flow
 
-    def build_powerflow_graph_beforecut(self):
+    def build_powerflow_graph_beforecut(self) -> nx.DiGraph:
         """
         Builds a graph of the grid and its powerflow before the lines are cut
         :return: NetworkX Graph of representing the grid
@@ -518,7 +547,7 @@ class Grid2opSimulation(Simulation):
         #g = build_powerflow_graph(self.topo, lines_cut)
         return PowerFlowGraph(self.topo, lines_cut).g
 
-    def build_powerflow_graph_aftercut(self):
+    def build_powerflow_graph_aftercut(self) -> nx.DiGraph:
         """
         Builds a graph of the grid and its powerflow after the lines have been cut
         :return: NetworkX Graph of representing the grid
@@ -527,13 +556,13 @@ class Grid2opSimulation(Simulation):
         #g = build_powerflow_graph(self.topo_linecut, lines_cut)
         return PowerFlowGraph(self.topo_linecut, lines_cut).g
 
-    def get_dataframe(self):
+    def get_dataframe(self) -> pd.DataFrame:
         """
         :return: pandas dataframe with topology information before and after line cutting
         """
         return self.df
 
-    def isAntenna(self):
+    def isAntenna(self) -> Optional[int]:
         linesAtBusbar_dic = self.getLinesAtSubAndBusbar()
 
         for sub in linesAtBusbar_dic.keys():
@@ -542,7 +571,7 @@ class Grid2opSimulation(Simulation):
                 return sub  # this is an Antenna
         return None
 
-    def isDoubleLine(self):
+    def isDoubleLine(self) -> Optional[List[int]]:
         ltc = self.ltc[0]
         obs = self.obs
 
@@ -567,7 +596,7 @@ class Grid2opSimulation(Simulation):
             return Common_lines
 
 
-    def getLinesAtSubAndBusbar(self):
+    def getLinesAtSubAndBusbar(self) -> Dict[Any, List[int]]:
         ltc = self.ltc[0]
         obs=self.obs
         linesAtBusbar_dic = {}
@@ -597,7 +626,7 @@ class Grid2opSimulation(Simulation):
         linesAtBusbar_dic[sub_ex] = linesAtBusbarEx
         return linesAtBusbar_dic
 
-    def build_detailed_graph_from_internal_structure(self, lines_to_cut):
+    def build_detailed_graph_from_internal_structure(self, lines_to_cut: List[int]) -> nx.MultiDiGraph:
         """This function create a detailed graph from internal self structures as self.substations_elements..."""
         g = nx.MultiDiGraph()
 
@@ -642,7 +671,7 @@ class Grid2opSimulation(Simulation):
     #    """
     #    return self.plot_grid(obs, name=name)
 
-    def plot(self,obs,save_file_path):
+    def plot(self, obs: Any, save_file_path: str) -> None:
         plot_helper = PlotMatplot(self.observation_space)
         fig_obs = plot_helper.plot_obs(obs, line_info='p')
         fig_obs.savefig(save_file_path)
@@ -661,7 +690,7 @@ class Grid2opSimulation(Simulation):
     #        fig_obs = self.plot_helper.plot_obs(obs, line_info='p')
     #        fig_obs.savefig(output_name[1])
 #
-    def change_nodes_configurations(self, new_configurations, node_ids, env):
+    def change_nodes_configurations(self, new_configurations: List[Any], node_ids: List[int], env: Any) -> Any:
         change = []
         for (conf, node) in zip(new_configurations, node_ids):
             change.append((node, conf))
@@ -673,7 +702,7 @@ class Grid2opSimulation(Simulation):
 
 
 
-def build_nodes_v2(g, nodes_prod_values: list):
+def build_nodes_v2(g: nx.MultiDiGraph, nodes_prod_values: List[Any]) -> None:
     """nodes_prod_values is a list of tuples, (graphical_node_id, prod_cons_total_value)
         prod_cons_total_value is a float.
         If the value is positive then it is a Production, if negative it is a Consumption
@@ -699,7 +728,11 @@ def build_nodes_v2(g, nodes_prod_values: list):
         i += 1
 
 
-def build_edges_v2(g, substation_id_busbar_id_node_id_mapping, substations_elements):
+def build_edges_v2(
+    g: nx.MultiDiGraph,
+    substation_id_busbar_id_node_id_mapping: Dict[int, Dict[int, int]],
+    substations_elements: Dict[int, List[Any]],
+) -> None:
     # print("\nWE ARE IN BUILD EDGES V2")
     substation_ids = sorted(list(substations_elements.keys()))
     # loops through each substation, and creates an edge from (
@@ -745,7 +778,12 @@ def build_edges_v2(g, substation_id_busbar_id_node_id_mapping, substations_eleme
 
 #TO DO: check is line is disconnected in new_obs
 
-def score_changes_between_two_observations(ltc, old_obs, new_obs,nb_timestep_cooldown_line_param=0):
+def score_changes_between_two_observations(
+    ltc: List[int],
+    old_obs: Any,
+    new_obs: Any,
+    nb_timestep_cooldown_line_param: int = 0,
+) -> Union[int, float]:
     """This function takes two observations and computes a score to quantify the change between old_obs and new_obs.
     @:return int between [0 and 4]
     4: if every overload disappeared

--- a/alphaDeesp/core/network.py
+++ b/alphaDeesp/core/network.py
@@ -8,6 +8,7 @@
 
 import logging
 import pprint
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
@@ -17,6 +18,7 @@ from alphaDeesp.core.elements import (
     OriginLine,
     Production,
 )
+from alphaDeesp.core.simulation import SubstationElement
 from alphaDeesp.core.twin_nodes import (
     is_twin_node_id,
     original_substation_id,
@@ -37,7 +39,7 @@ class Network:
         self.substation_id_busbar_id_node_id_mapping = substation_id_busbar_id_to_node_id_mapping
 
     """
-    def __init__(self, substations_elements: dict):
+    def __init__(self, substations_elements: Dict[int, List[SubstationElement]]) -> None:
         logger.debug("A Network got created...")
 
         nodes = sorted(list(substations_elements.keys()))
@@ -100,8 +102,8 @@ class Network:
 
         ################################
         ################################
-        final_array_for_drawing_nodes = []
-        save_for_complementary_nodes = []
+        final_array_for_drawing_nodes: List[Tuple[Any, Any]] = []
+        save_for_complementary_nodes: List[Tuple[Any, Any]] = []
         # LOOP THROUGH SUBSTATIONS
         for substation_id in nodes:
             for busbar in mapping_node_id_to_prod_minus_load[substation_id].keys():
@@ -127,7 +129,7 @@ class Network:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("final_array_for_drawing_nodes (with complementaries)\n%s",
                          pprint.pformat(final_array_for_drawing_nodes))
-        self.nodes_prod_values = final_array_for_drawing_nodes
+        self.nodes_prod_values: List[Tuple[Any, Any]] = final_array_for_drawing_nodes
 
         #####################################################################################################
         # ##################################### EDGE PART PREPROCESSING #####################################
@@ -179,17 +181,19 @@ class Network:
             logger.debug("substation_id_busbar_id_to_node_id_mapping\n%s",
                          pprint.pformat(substation_id_busbar_id_to_node_id_mapping))
 
-        self.substation_id_busbar_id_node_id_mapping = substation_id_busbar_id_to_node_id_mapping
-        self.nb_graphical_nodes = len(list(substation_id_busbar_id_to_node_id_mapping.keys()))
+        self.substation_id_busbar_id_node_id_mapping: Dict[int, Dict[int, Any]] = (
+            substation_id_busbar_id_to_node_id_mapping
+        )
+        self.nb_graphical_nodes: int = len(list(substation_id_busbar_id_to_node_id_mapping.keys()))
         logger.debug("There are %s graphical nodes in this graph.", self.nb_graphical_nodes)
 
 
-    def get_number_total_number_of_nodes(self):
+    def get_number_total_number_of_nodes(self) -> None:
         """
         Nodes, meaning counting splits if diff busbars
         :return:
         """
         pass
 
-    def get_graphical_number_of_nodes(self):
+    def get_graphical_number_of_nodes(self) -> int:
         return self.nb_graphical_nodes

--- a/alphaDeesp/core/printer.py
+++ b/alphaDeesp/core/printer.py
@@ -12,6 +12,7 @@ import datetime
 import logging
 import os
 import subprocess
+from typing import List, Optional, Tuple
 
 import networkx as nx
 
@@ -21,9 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 class Printer:
-    save_id_number = 0
+    save_id_number: int = 0
 
-    def __init__(self, output_path = None):
+    def __init__(self, output_path: Optional[str] = None) -> None:
         if output_path is None:
             self.default_output_path = "alphaDeesp/ressources/output"
         else:
@@ -34,7 +35,18 @@ class Printer:
         os.makedirs(self.results_output_path, exist_ok=True)
         logger.debug("self.default output path = %s", self.default_output_path)
 
-    def plot_graphviz(self, g, custom_layout=None,rescale_factor=None,allow_overlap=True,fontsize=None,node_thickness=3, axial_symetry=False, save=False, name=None):
+    def plot_graphviz(
+        self,
+        g: nx.DiGraph,
+        custom_layout: Optional[List[Tuple[float, float]]] = None,
+        rescale_factor: Optional[float] = None,
+        allow_overlap: bool = True,
+        fontsize: Optional[int] = None,
+        node_thickness: int = 3,
+        axial_symetry: bool = False,
+        save: bool = False,
+        name: Optional[str] = None,
+    ) -> bytes:
         "filenames are pathlib.Paths objects"
 
         dic_pos_attributes = {}
@@ -82,7 +94,17 @@ class Printer:
 
 
 
-    def display_geo(self, g, custom_layout=None,rescale_factor=None,fontsize=None, node_thickness=3, axial_symetry=False, save=False, name=None):
+    def display_geo(
+        self,
+        g: nx.DiGraph,
+        custom_layout: Optional[List[Tuple[float, float]]] = None,
+        rescale_factor: Optional[float] = None,
+        fontsize: Optional[int] = None,
+        node_thickness: int = 3,
+        axial_symetry: bool = False,
+        save: bool = False,
+        name: Optional[str] = None,
+    ) -> None:
         """This function displays the graph g in a "geographical" way"""
 
         "filenames are pathlib.Paths objects"
@@ -148,10 +170,15 @@ class Printer:
         #     os.system("rm " + filename_dot)
         #     os.system("rm " + filename_pdf)
 
-    def display_elec(self, g, save=False):
+    def display_elec(self, g: nx.DiGraph, save: bool = False) -> None:
         pass
 
-    def create_namefile(self, display_type, name=None, type = "results"):
+    def create_namefile(
+        self,
+        display_type: str,
+        name: Optional[str] = None,
+        type: str = "results",
+    ) -> Tuple[str, str]:
         """return dot and pdf filenames"""
         # filename_dot = "graph_result_" + display_type + "_" + current_date + ".dot"
         # filename_pdf = "graph_result_" + display_type + "_" + current_date + ".pdf"
@@ -183,7 +210,7 @@ class Printer:
         return hard_filename_dot, hard_filename_pdf
 
 
-def shell_print_project_header():
+def shell_print_project_header() -> None:
     os.system("cat ./print_header.txt")
 
 ########################################################################################################################
@@ -191,7 +218,7 @@ def shell_print_project_header():
 ########################################################################################################################
 
 
-def execute_command(command: str):
+def execute_command(command: str) -> bool:
     """
     This function executes a command on the local machine, and fill self.output and self.error with results of
     command.

--- a/alphaDeesp/core/pypownet/PypownetSimulation.py
+++ b/alphaDeesp/core/pypownet/PypownetSimulation.py
@@ -1,9 +1,11 @@
 from math import fabs
 import ast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import networkx as nx
 from pypownet.environment import ElementType
 import numpy as np
+import pandas as pd
 
 from alphaDeesp.core.elements import (
     Consumption,
@@ -17,7 +19,17 @@ from alphaDeesp.core.printer import Printer
 
 
 class PypownetSimulation(Simulation):
-    def __init__(self, env, obs, action_space, param_options=None, debug=False, ltc=None, plot_folder=None, isScoreFromBackend=False):
+    def __init__(
+        self,
+        env: Any,
+        obs: Any,
+        action_space: Any,
+        param_options: Optional[Dict[str, Any]] = None,
+        debug: bool = False,
+        ltc: Optional[List[int]] = None,
+        plot_folder: Optional[str] = None,
+        isScoreFromBackend: bool = False,
+    ) -> None:
         super().__init__()
         print("PypownetSimulation object created...")
 
@@ -63,7 +75,7 @@ class PypownetSimulation(Simulation):
         print(self.obs)
         self.load()
 
-    def compute_layout(self):
+    def compute_layout(self) -> List[Tuple[float, float]]:
         try:
             layout = self.param_options['CustomLayout']
             # Conversion from string to list
@@ -75,49 +87,49 @@ class PypownetSimulation(Simulation):
                     (438, 100), (326, 140), (200, 8), (79, 12), (-152, 170), (-70, 200), (222, 200)]
         return layout
 
-    def get_layout(self):
+    def get_layout(self) -> List[Tuple[float, float]]:
         return self.layout
 
-    def get_substation_elements(self):
+    def get_substation_elements(self) -> Dict[int, List[Any]]:
         return self.substations_elements
 
-    def get_substation_to_node_mapping(self):
+    def get_substation_to_node_mapping(self) -> Optional[Dict[int, Any]]:
         return self.substation_to_node_mapping
 
-    def get_internal_to_external_mapping(self):
+    def get_internal_to_external_mapping(self) -> Dict[int, int]:
         return self.internal_to_external_mapping
 
-    def get_dataframe(self):
+    def get_dataframe(self) -> pd.DataFrame:
         """
         :return: pandas dataframe with topology information before and after line cutting
         """
         return self.df
 
-    def isAntenna(self):
+    def isAntenna(self) -> Optional[int]:
         """TODO"""
         return None
 
-    def isDoubleLine(self):
+    def isDoubleLine(self) -> Optional[List[int]]:
         """TODO"""
         return None
 
-    def getLinesAtSubAndBusbar(self):
+    def getLinesAtSubAndBusbar(self) -> Dict[Any, List[int]]:
         """TODO"""
         return None
 
-    def get_overload_disconnection_topovec_subor(self, l):
+    def get_overload_disconnection_topovec_subor(self, l: int) -> Tuple[Optional[int], Optional[List[int]]]:
         """TODO"""
         return None,None
 
-    def get_reference_topovec_sub(self,sub):
+    def get_reference_topovec_sub(self, sub: int) -> Optional[List[int]]:
         """TODO"""
         return None
 
-    def get_substation_in_cooldown(self):
+    def get_substation_in_cooldown(self) -> Optional[List[int]]:
         """TODO"""
         return None
 
-    def compute_new_network_changes(self, ranked_combinations):
+    def compute_new_network_changes(self, ranked_combinations: List[pd.DataFrame]) -> pd.DataFrame:
         """this function takes a dataframe ranked_combinations,
          for each combination it computes a simulation step in Pypownet with action:
          change nodes topo(combination)"""
@@ -244,7 +256,13 @@ class PypownetSimulation(Simulation):
 
         return end_result_dataframe
 
-    def observations_comparator(self, old_obs, new_obs, score_topo, delta_flow):
+    def observations_comparator(
+        self,
+        old_obs: Any,
+        new_obs: Any,
+        score_topo: Any,
+        delta_flow: float,
+    ) -> Tuple[Any, Any, float, float, float]:
         """This function takes two observations and extracts several information:
         - the flow reports in %
         - list of lines, on which the situation got worse ie, the line capacity diminished.
@@ -274,7 +292,7 @@ class PypownetSimulation(Simulation):
 
         return simulated_score, worsened_line_ids, redistribution_prod, redistribution_load, efficacity
 
-    def create_boolean_array_of_worsened_line_ids(self, old_obs, new_obs):
+    def create_boolean_array_of_worsened_line_ids(self, old_obs: Any, new_obs: Any) -> np.ndarray:
         """This function creates a boolean array of lines that got worse between two observations.
         @:return boolean numpy array [0..1]"""
 
@@ -300,7 +318,12 @@ class PypownetSimulation(Simulation):
 
         return np.array(res)
 
-    def score_changes_between_two_observations(self, old_obs, new_obs,nb_timestep_cooldown_line_param=0):
+    def score_changes_between_two_observations(
+        self,
+        old_obs: Any,
+        new_obs: Any,
+        nb_timestep_cooldown_line_param: int = 0,
+    ) -> Union[int, float]:
         """This function takes two observations and computes a score to quantify the change between old_obs and new_obs.
         @:return int between [0 and 4]
         4: if every overload disappeared
@@ -414,7 +437,7 @@ class PypownetSimulation(Simulation):
         else:
             raise ValueError("Probleme with Scoring")
 
-    def create_and_fill_internal_structures(self, obs, df):
+    def create_and_fill_internal_structures(self, obs: Any, df: pd.DataFrame) -> None:
         """This function fills multiple structures:
         self.substation_elements, self.substation_to_node_mapping, self.internal_to_external_mapping
         @:arg observation, df"""
@@ -532,10 +555,10 @@ class PypownetSimulation(Simulation):
 
             self.substations_elements[substation_id] = elements_array
 
-    def load(self):
+    def load(self) -> None:
         self.load_from_observation(self.obs, self.ltc)
 
-    def load_from_observation(self, observation, lines_to_cut: list):
+    def load_from_observation(self, observation: Any, lines_to_cut: List[int]) -> None:
         # first, load information into a data frame
         self.ltc = lines_to_cut
         # d is a dict containing topology
@@ -548,7 +571,7 @@ class PypownetSimulation(Simulation):
         self.create_and_fill_internal_structures(observation, df)
 
 
-    def build_detailed_graph_from_internal_structure(self, lines_to_cut):
+    def build_detailed_graph_from_internal_structure(self, lines_to_cut: List[int]) -> nx.MultiDiGraph:
         """This function create a detailed graph from internal self structures as self.substations_elements..."""
         g = nx.MultiDiGraph()
         network = Network(self.substations_elements)
@@ -558,7 +581,7 @@ class PypownetSimulation(Simulation):
         print("This graph is weakly connected : ", nx.is_weakly_connected(g))
         return g
 
-    def change_nodes_configurations(self, new_configuration, node_id):
+    def change_nodes_configurations(self, new_configuration: Any, node_id: Any) -> Any:
         """Changes pypownet's internal graph network by changing node : node_id by applying new_configuration"""
 
         action_space = self.environment.action_space
@@ -575,7 +598,7 @@ class PypownetSimulation(Simulation):
         return obs
 
     @staticmethod
-    def extract_topo_from_obs(obs):
+    def extract_topo_from_obs(obs: Any) -> Dict[str, Dict[str, Any]]:
         """This function, takes an obs an returns a dict with all topology information"""
         d = {
             "edges": {},
@@ -602,7 +625,7 @@ class PypownetSimulation(Simulation):
         d["nodes"]["loads_values"] = loads_values
         return d
 
-    def cut_lines_and_recomputes_flows(self, ids: list):
+    def cut_lines_and_recomputes_flows(self, ids: List[int]) -> Sequence[float]:
         """This functions cuts lines: [ids], simulates and returns new line flows"""
         action_space = self.environment.action_space
         action = action_space.get_do_nothing_action(as_class_Action=True)
@@ -618,7 +641,7 @@ class PypownetSimulation(Simulation):
         return obs.active_flows_origin
 
 
-def build_nodes_v2(g, nodes_prod_values: list):
+def build_nodes_v2(g: nx.MultiDiGraph, nodes_prod_values: List[Any]) -> None:
     """nodes_prod_values is a list of tuples, (graphical_node_id, prod_cons_total_value)
         prod_cons_total_value is a float.
         If the value is positive then it is a Production, if negative it is a Consumption
@@ -644,7 +667,11 @@ def build_nodes_v2(g, nodes_prod_values: list):
         i += 1
 
 
-def build_edges_v2(g, substation_id_busbar_id_node_id_mapping, substations_elements):
+def build_edges_v2(
+    g: nx.MultiDiGraph,
+    substation_id_busbar_id_node_id_mapping: Dict[Any, Any],
+    substations_elements: Dict[int, List[Any]],
+) -> None:
     print("\nWE ARE IN BUILD EDGES V2")
     substation_ids = sorted(list(substations_elements.keys()))
     # loops through each substation, and creates an edge from (
@@ -689,7 +716,7 @@ def build_edges_v2(g, substation_id_busbar_id_node_id_mapping, substations_eleme
             g.add_edge(origin, extremity, capacity=float(reported_flow[0]), label=reported_flow[0])
 
 
-def get_differencial_topology(new_conf, old_conf):
+def get_differencial_topology(new_conf: List[int], old_conf: List[int]) -> List[int]:
     """new - old, for elem in result, if elem -1, then put one"""
     assert (len(new_conf) == len(old_conf))
     res = []

--- a/alphaDeesp/core/simulation.py
+++ b/alphaDeesp/core/simulation.py
@@ -26,6 +26,12 @@ SubstationElement = Union[Production, Consumption, OriginLine, ExtremityLine]
 class Simulation(ABC):
     """Abstract Class Simulation"""
 
+    #: Backend-provided runtime configuration (thresholds, layout, etc.)
+    #: populated by concrete subclasses in their own ``__init__``.
+    param_options: Dict[str, Any]
+    #: Debug flag consulted by :meth:`create_df`; concrete subclasses set it.
+    debug: bool
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -184,7 +190,7 @@ class Simulation(ABC):
     def create_end_result_empty_dataframe() -> pd.DataFrame:
         """This function creates initial structure for the dataframe"""
 
-        end_result_dataframe_structure_initiation = {
+        end_result_dataframe_structure_initiation: Dict[str, List[Any]] = {
             "overflow ID": [],
             "Flows before": [],
             "Flows after": [],

--- a/docs/code-quality-analysis.md
+++ b/docs/code-quality-analysis.md
@@ -1,14 +1,20 @@
 # Code Quality & Maintainability Analysis
 
-_Last updated: 2026-04-12 — high-impact items 5, 6, 7 and 9 are now all
-resolved on branch `claude/fix-code-quality-issues-XGpMU` (type hints on
-`core/simulation.py` and `core/elements.py`; remaining mutable defaults on
-`Grid2opSimulation.__init__` / `PypownetSimulation.__init__`; items 5 and 7
-were already done in prior passes and are reconfirmed). Longer-term refactors
-for the four highest-CC functions and the `"666"` twin-node encoding landed
-on branch `claude/refactor-rank-topo-function-U4y9g`. Short-term action plan
-landed on `claude/code-quality-short-term-tnydm`; original immediate-cleanup
-pass on `claude/code-quality-analysis-8Ftgi`._
+_Last updated: 2026-04-13 — item 14 (type hints propagation + mypy in CI) is
+now resolved on branch `claude/add-type-hints-mypy-PkQvf`: the remaining six
+modules (`core/alphadeesp.py`, `core/graphsAndPaths.py`, `core/network.py`,
+`core/printer.py`, `core/grid2op/Grid2opSimulation.py`,
+`core/pypownet/PypownetSimulation.py`) have signature-level annotations,
+`mypy --ignore-missing-imports` is wired into CircleCI (strict for the two
+seed modules, permissive for the rest), and `radon cc/mi/raw` runs on every
+build as an informational "code quality report" step. Previous passes:
+high-impact items 5, 6, 7 and 9 on `claude/fix-code-quality-issues-XGpMU`
+(initial type hints seed for `core/simulation.py` and `core/elements.py`;
+remaining mutable defaults). Longer-term refactors for the four highest-CC
+functions and the `"666"` twin-node encoding landed on
+`claude/refactor-rank-topo-function-U4y9g`. Short-term action plan landed on
+`claude/code-quality-short-term-tnydm`; original immediate-cleanup pass on
+`claude/code-quality-analysis-8Ftgi`._
 
 This document captures a diagnostic review of the `alphaDeesp` (ExpertOp4Grid)
 codebase. It is intended as a living punch-list for incremental cleanup work.
@@ -100,6 +106,9 @@ and discrimination are covered in `TestTwinNodeIds`.
 | done | Unify `LICENSE`/`LICENSE.md`; refresh `setup.py` classifiers and version pins | See "Packaging cleanup" below |
 | done | Fix remaining mutable defaults on `Grid2opSimulation.__init__` / `PypownetSimulation.__init__` | See "Mutable defaults" below |
 | done | Type hints seed on `core/simulation.py` and `core/elements.py` | See "Type hints seed" below |
+| done | Type hints propagation to `alphadeesp.py`, `graphsAndPaths.py`, `network.py`, `printer.py`, `Grid2opSimulation.py`, `PypownetSimulation.py` | See "Type hints propagation" below |
+| done | Enable `mypy --ignore-missing-imports` in CI (strict for the two seed modules, permissive for the rest) | See "Mypy in CI" below |
+| done | Automate code quality metrics (pyflakes + mypy + radon cc/mi/raw) in CircleCI | See "Code quality metrics in CI" below |
 
 ### Bare except cleanup
 
@@ -240,17 +249,191 @@ What landed:
     OriginLine, ExtremityLine]`` alias is exposed so downstream annotations
     can use a single name instead of repeating the 4-way union.
 
-Deliberately out of scope for this pass (tracked under longer-term item 14):
+All of the modules that were deferred in the seed pass now carry
+signature-level annotations — see "Type hints propagation" below. Mypy is
+also wired into CI; see "Mypy in CI" below.
 
-- `core/alphadeesp.py`, `core/graphsAndPaths.py`, `core/network.py`,
-  `core/printer.py`, and the two concrete backends
-  (`core/grid2op/Grid2opSimulation.py`, `core/pypownet/PypownetSimulation.py`).
-  These modules consume the seed types but annotating them requires
-  carefully typing `networkx.DiGraph` / `rustworkx.PyDiGraph` nodes and
-  edges, which is a larger job.
-- Wiring `mypy --ignore-missing-imports` into CI. With only the two seed
-  modules annotated mypy would be almost entirely noise; it makes sense to
-  enable it once `alphadeesp.py` and the backends are typed.
+### Type hints propagation
+
+The six modules the seed pass left untyped now carry **public
+signature-level** annotations (parameters + return types). Internal locals
+are still untyped in most cases — the goal of this pass was to surface
+enough of the shape of the package that `mypy --ignore-missing-imports` can
+run over the whole first-party tree without `Any`-chasing every call site.
+
+| Module | Annotated signatures (approximate) |
+|---|---|
+| `core/printer.py` | 7 methods/functions: `Printer.__init__`, `plot_graphviz`, `display_geo`, `display_elec`, `create_namefile`, `shell_print_project_header`, `execute_command`. |
+| `core/network.py` | `Network.__init__(substations_elements: Dict[int, List[SubstationElement]])`, `get_number_total_number_of_nodes`, `get_graphical_number_of_nodes` + the `nodes_prod_values` / `substation_id_busbar_id_node_id_mapping` / `nb_graphical_nodes` attributes. |
+| `core/alphadeesp.py` | ~38 signatures — `__init__`, `simulate_network_change`, `get_ranked_combinations`, `compute_best_topologies`, `clean_and_sort_best_topologies`, `compute_all_combinations`, `legal_comb`, `rank_topologies`, `apply_new_topo_to_graph` + 5 helpers, `rank_current_topo_at_node_x` + 4 `_score_*` helpers, `_pick_interesting_bus_id`, `_collect_flows_on_bus`, `get_prod_conso_sum`, `get_bus_id_from_edge`, `is_connected_to_cpath`, `sort_hubs`, `identify_routing_buses`, `rank_loop_buses`, `rank_red_loops`, `to_DiGraph`, `compute_meaningful_structures`, `get_adjacency_matrix`, `get_loop_paths`, `filter_constrained_path`, `isAntenna`, `write_g`, `read_g`, `AlphaDeesp_warmStart.__init__`. |
+| `core/graphsAndPaths.py` | ~76 signatures across `PowerFlowGraph`, `OverFlowGraph`, `ConstrainedPath`, `Structured_Overload_Distribution_Graph`, plus 11 module-level graph helpers (`from_edges_get_nodes`, `delete_color_edges`, `nodepath_to_edgepath`, `incident_edges`, `all_simple_edge_paths_multi`, `remove_unused_added_double_edge`, `add_double_edges_null_redispatch`, `find_multidigraph_edges_by_name`, `shortest_path_min_weight_then_hops`, `shortest_path_mandatory_and_promoted`, `shortest_path_with_promoted_edges`). |
+| `core/grid2op/Grid2opSimulation.py` | ~33 signatures covering every method of `Grid2opSimulation` plus the three module-level helpers `build_nodes_v2`, `build_edges_v2`, `score_changes_between_two_observations`. |
+| `core/pypownet/PypownetSimulation.py` | ~27 signatures covering every method of `PypownetSimulation` plus `build_nodes_v2`, `build_edges_v2`, `get_differencial_topology`. This module is outside the pyflakes/mypy CI scope because `pypownet` is an optional backend, but annotating it still helps IDE support for users who opt into it. |
+
+Type-annotated function count in the first-party tree went from **36**
+after the seed pass to **~220** return-type annotations after this one
+(`grep -c '-> ' alphaDeesp/core/*.py alphaDeesp/core/*/*.py`).
+
+Guidelines used throughout the propagation pass:
+
+- **`Any` was preferred over guessing** whenever the runtime type is a
+  backend-specific object (Grid2op observations, pypownet environments,
+  rustworkx PyDiGraph). `mypy --ignore-missing-imports` does not need
+  precise types to catch the common errors.
+- **`networkx.MultiDiGraph` / `nx.DiGraph`** was used for graph parameters
+  where the class contract is clear.
+- **`pandas.DataFrame`** and **`Sequence[float]`** were used for
+  dataframe and flow-vector parameters.
+- Abstract-base-class return types were propagated through to the two
+  concrete backends (`Grid2opSimulation`, `PypownetSimulation`) so
+  `Liskov`-style checks work: `isAntenna -> Optional[int]`,
+  `isDoubleLine -> Optional[List[int]]`,
+  `getLinesAtSubAndBusbar -> Dict[Any, List[int]]`,
+  `get_layout -> List[Tuple[float, float]]`,
+  `get_substation_in_cooldown -> List[int]`,
+  `get_substation_elements -> Dict[int, List[SubstationElement]]`.
+- **Mutable defaults were not rewritten** in this pass — the existing
+  `= []` defaults are annotated as `List[Any] = []` and the mutable-
+  default lint finding (where applicable) is tracked separately.
+- **No refactors, no semantic changes.** Only `def` signatures were
+  touched and `typing` imports added at the top of each module.
+
+A few base-class-level attribute annotations were added on
+`Simulation` so that the strict-mode seed modules keep passing mypy
+after the propagation landed:
+
+```python
+class Simulation(ABC):
+    # Backend-provided runtime configuration (thresholds, layout, etc.)
+    # populated by concrete subclasses in their own __init__.
+    param_options: Dict[str, Any]
+    # Debug flag consulted by create_df; concrete subclasses set it.
+    debug: bool
+```
+
+and `create_end_result_empty_dataframe` picked up an explicit
+`end_result_dataframe_structure_initiation: Dict[str, List[Any]]`
+annotation so the strict-mode run no longer trips on the previously
+inferred `dict[str, list[<nothing>]]`.
+
+### Mypy in CI
+
+The CircleCI `build-and-test` job now installs `mypy` alongside
+`pyflakes` and runs a two-stage type-check after the pyflakes lint
+step:
+
+```yaml
+- run:
+    name: Run mypy (static type check)
+    command: |
+      python -m mypy \
+        alphaDeesp/core/simulation.py \
+        alphaDeesp/core/elements.py
+      python -m mypy \
+        alphaDeesp/core/network.py \
+        alphaDeesp/core/printer.py \
+        alphaDeesp/core/alphadeesp.py \
+        alphaDeesp/core/graphsAndPaths.py \
+        alphaDeesp/core/twin_nodes.py \
+        alphaDeesp/core/grid2op/Grid2opSimulation.py \
+        alphaDeesp/core/grid2op/Grid2opObservationLoader.py \
+        alphaDeesp/expert_operator.py \
+        alphaDeesp/main.py || true
+```
+
+The first `mypy` invocation is **strict for the two seed modules** — a
+new type error in `core/simulation.py` or `core/elements.py` fails the
+build. The second invocation runs in **permissive mode** over the rest
+of the first-party tree and is guarded by `|| true` so its findings are
+informational until the whole package is annotated at the local-
+variable level.
+
+Configuration lives in `setup.cfg` under a new `[mypy]` section:
+
+```ini
+[mypy]
+python_version = 3.12
+ignore_missing_imports = True
+follow_imports = silent
+warn_unused_ignores = False
+warn_return_any = False
+warn_redundant_casts = True
+no_strict_optional = True
+allow_untyped_defs = True
+allow_untyped_calls = True
+allow_incomplete_defs = True
+exclude = (alphaDeesp/core/pypownet/|alphaDeesp/tests/pypownet/|alphaDeesp/Expert_rule_action_verification\.py|alphaDeesp/ressources/)
+
+[mypy-alphaDeesp.core.simulation]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-alphaDeesp.core.elements]
+disallow_untyped_defs = True
+check_untyped_defs = True
+```
+
+`ignore_missing_imports = True` silences the missing-stub noise from
+`grid2op`, `lightsim2grid`, `networkx`, `rustworkx`, `pypowsybl` and
+friends. `follow_imports = silent` keeps the permissive run from
+cascading into strict-scope errors. The legacy Pypownet backend, the
+optional-toolbox `Expert_rule_action_verification.py`, and the ad-hoc
+`ressources/parameters/*.py` scripts are excluded — they match the
+existing pyflakes / pytest CI exclusions.
+
+**Current mypy status** (local, 2026-04-13):
+
+- Strict seed (`core/simulation.py`, `core/elements.py`): **0 errors**.
+- Permissive scope (9 modules): **~51 errors**, all of them either
+  "needs a type annotation for a local dict/list" or
+  "incompatible int / float assignment" inside AlphaDeesp hot loops.
+  These are tracked as follow-up work but do not gate the build.
+
+### Code quality metrics in CI
+
+The CircleCI job now also runs `radon` after the lint/type-check
+phases, as a dedicated **"Code quality metrics"** step:
+
+```yaml
+- run:
+    name: Code quality metrics (radon)
+    command: |
+      echo "=== Cyclomatic complexity (A-F, min: C) ==="
+      python -m radon cc -a -s --min C \
+        alphaDeesp/core/ \
+        alphaDeesp/Expert_rule_action_verification.py || true
+      echo ""
+      echo "=== Maintainability Index (all modules) ==="
+      python -m radon mi -s \
+        alphaDeesp/core/ \
+        alphaDeesp/Expert_rule_action_verification.py || true
+      echo ""
+      echo "=== Raw metrics (SLOC / comment ratio) ==="
+      python -m radon raw -s \
+        alphaDeesp/core/ \
+        alphaDeesp/Expert_rule_action_verification.py || true
+```
+
+- The **cyclomatic-complexity** report surfaces any new function that
+  crosses into the C grade (CC ≥ 11), which is the threshold the
+  longer-term refactor work flagged as the upper bound for acceptable
+  helpers (the dispatcher functions are all at B (7) after the
+  "Longer-term refactor landing" pass).
+- The **maintainability index** report tracks MI for every module in
+  the package so regressions in `graphsAndPaths.py` (already at C),
+  `Grid2opSimulation.py`, `PypownetSimulation.py` and
+  `Expert_rule_action_verification.py` are visible per build.
+- The **raw metrics** report keeps SLOC / comment ratio / blank-line
+  ratio visible so the "largest module" and "comment-to-code density"
+  numbers in the Metrics table above stay fresh.
+
+Each `radon` command is guarded with `|| true` so the step is
+**purely informational**; it never fails the build. The test suite
+still gates the pipeline.
+
+This is the single-command replacement for the "How to reproduce these
+metrics" section at the bottom of this document — developers no longer
+need to run `radon` locally to see where they stand.
 
 Verification:
 
@@ -424,7 +607,7 @@ CI-config change.
 | Average complexity | **B (5.72)** across 163 functions/classes | `radon cc` |
 | `print()` calls | baseline: **247** across 20 files → **~108 remaining** (tests, `build_new_parameters_environment.py`, legacy Pypownet backend, `Expert_rule_action_verification.py`); all 10 CI-scoped first-party modules are at **0** | grep |
 | Bare `except:` clauses | baseline: 9 → **0** | grep |
-| Type-annotated functions | baseline 1 → **36** after the core base-class seed (16 in `core/elements.py` + 20 in `core/simulation.py`); rest of the package still untyped | grep `-> ` |
+| Type-annotated functions | baseline 1 → **36** after the seed → **~220** after the propagation pass (20 in `simulation.py`, 16 in `elements.py`, 3 in `network.py`, 7 in `printer.py`, 38 in `alphadeesp.py`, 76 in `graphsAndPaths.py`, 33 in `Grid2opSimulation.py`, 27 in `PypownetSimulation.py`) | grep `-> ` |
 | Pyflakes findings | baseline: 59 → **0** in CI scope | `pyflakes` |
 | TODO/FIXME markers | 25 across 7 files | grep |
 | Test functions | 164 across 9 files; CI now only excludes `test_cli.py` (run as a dedicated step); pypownet + expert_rules self-skip via `pytest.importorskip` | `.circleci/config.yml` |
@@ -619,18 +802,32 @@ details of each change.
     `apply_new_topo_to_graph`.~~ Done — F (46)/F (44)/E (36) → A (2)/B (7)/B (7).
 13. ~~Replace the `"666"` twin-node encoding with a proper id scheme.~~ Done,
     see `alphaDeesp/core/twin_nodes.py`.
-14. Add type hints starting from `core/simulation.py` and `core/elements.py`
-    outward; enable `mypy --ignore-missing-imports` in CI. _Seed done for
-    the two base-class modules — see "Type hints seed" above. Remaining:
-    `core/alphadeesp.py`, `core/graphsAndPaths.py`, `core/network.py`,
-    `core/printer.py`, and the two concrete simulator backends._
+14. ~~Add type hints starting from `core/simulation.py` and `core/elements.py`
+    outward; enable `mypy --ignore-missing-imports` in CI.~~ Done — all six
+    previously untyped modules (`core/alphadeesp.py`,
+    `core/graphsAndPaths.py`, `core/network.py`, `core/printer.py`,
+    `core/grid2op/Grid2opSimulation.py`,
+    `core/pypownet/PypownetSimulation.py`) now carry signature-level
+    annotations, and `mypy --ignore-missing-imports` is wired into
+    CircleCI in strict mode for the seed and permissive mode for the rest
+    of the first-party tree. See "Type hints propagation", "Mypy in CI",
+    and "Code quality metrics in CI" above. **Remaining nits** (not
+    blockers): ~51 permissive-mode mypy findings, mostly
+    "needs-local-annotation" on internal dicts/lists inside
+    `alphadeesp.py` and `Grid2opSimulation.py`, plus a handful of
+    `int`/`float` assignment mismatches in AlphaDeesp hot loops. These
+    are tracked as an item-14 follow-up and do not gate the build.
 15. Decide the fate of the Pypownet backend: first-class (re-enable CI,
     modernize) or deprecated.
 
 ## How to reproduce these metrics
 
+_CircleCI runs pyflakes, mypy, and radon automatically on every build —
+see "Code quality metrics in CI" above. The commands below reproduce the
+same reports locally._
+
 ```bash
-pip install pyflakes radon
+pip install pyflakes mypy radon
 
 # Complexity
 python -m radon cc -a -s alphaDeesp/core/alphadeesp.py \
@@ -647,6 +844,15 @@ python -m radon raw -s alphaDeesp/core/ alphaDeesp/Expert_rule_action_verificati
 
 # Unused code and star-import leaks
 python -m pyflakes alphaDeesp/core alphaDeesp/*.py
+
+# Static type checking (same two-stage invocation as CI)
+python -m mypy alphaDeesp/core/simulation.py alphaDeesp/core/elements.py
+python -m mypy alphaDeesp/core/network.py alphaDeesp/core/printer.py \
+    alphaDeesp/core/alphadeesp.py alphaDeesp/core/graphsAndPaths.py \
+    alphaDeesp/core/twin_nodes.py \
+    alphaDeesp/core/grid2op/Grid2opSimulation.py \
+    alphaDeesp/core/grid2op/Grid2opObservationLoader.py \
+    alphaDeesp/expert_operator.py alphaDeesp/main.py || true
 
 # Print statements
 grep -rn --include='*.py' '^\s*print(' alphaDeesp/ | wc -l

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,38 @@ filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
     ignore:.*U.*mode is deprecated:DeprecationWarning
 
+
+# ---------------------------------------------------------------------------
+# mypy — incremental roll-out. See docs/code-quality-analysis.md, item 14.
+#
+# The core base-class modules (`simulation.py`, `elements.py`) are fully
+# annotated and enforced in strict-ish mode. The rest of the package has
+# signature-level annotations only; internal locals remain untyped, so we
+# keep permissive flags until the codebase catches up. Runtime dependencies
+# without PEP-561 type stubs (grid2op, lightsim2grid, pypownet, pypowsybl,
+# networkx, rustworkx) are silenced via `ignore_missing_imports = True`.
+# ---------------------------------------------------------------------------
+[mypy]
+python_version = 3.12
+ignore_missing_imports = True
+follow_imports = silent
+warn_unused_ignores = False
+warn_return_any = False
+warn_redundant_casts = True
+no_strict_optional = True
+allow_untyped_defs = True
+allow_untyped_calls = True
+allow_incomplete_defs = True
+# Skip the legacy Pypownet backend — pypownet is optional and may not be
+# installed where mypy runs.
+exclude = (alphaDeesp/core/pypownet/|alphaDeesp/tests/pypownet/|alphaDeesp/Expert_rule_action_verification\.py|alphaDeesp/ressources/)
+
+# Strict-ish mode only for the annotated seed modules — regressions here
+# should fail the build.
+[mypy-alphaDeesp.core.simulation]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-alphaDeesp.core.elements]
+disallow_untyped_defs = True
+check_untyped_defs = True


### PR DESCRIPTION
## Summary

This PR completes the type-hints rollout across the alphaDeesp codebase and integrates static type checking and code quality metrics into the CircleCI pipeline.

## Key Changes

**Type Hints Propagation**
- Added signature-level type annotations to six previously untyped modules:
  - `core/alphadeesp.py` (~38 signatures)
  - `core/graphsAndPaths.py` (~76 signatures)
  - `core/network.py` (3 key signatures + attributes)
  - `core/printer.py` (7 methods/functions)
  - `core/grid2op/Grid2opSimulation.py` (~33 signatures)
  - `core/pypownet/PypownetSimulation.py` (~27 signatures)
- Type-annotated function count increased from 36 to ~220 return-type annotations
- Added base-class-level attribute annotations on `Simulation` (`param_options`, `debug`) to support strict-mode checking in seed modules
- Used `Any` pragmatically for backend-specific objects (Grid2op observations, pypownet environments, rustworkx graphs) where precise types are unavailable
- No semantic changes or refactors—only `def` signatures and `typing` imports were modified

**Mypy Integration in CI**
- Added `mypy --ignore-missing-imports` to CircleCI `build-and-test` job
- Two-stage type checking:
  - **Strict mode** for seed modules (`core/simulation.py`, `core/elements.py`) — failures block the build
  - **Permissive mode** for remaining modules — informational only (`|| true` guard)
- Configuration in `setup.cfg` with per-module overrides
- Excludes legacy Pypownet backend, optional toolbox scripts, and resource files to match existing CI scope
- Current status: 0 errors in strict scope, ~51 errors in permissive scope (mostly local variable annotations and int/float assignments in hot loops)

**Code Quality Metrics in CI**
- Added `radon` step to CircleCI for automated code quality reporting:
  - **Cyclomatic complexity** (A-F grades, minimum C threshold)
  - **Maintainability Index** (per-module tracking)
  - **Raw metrics** (SLOC, comment ratio, blank-line ratio)
- All `radon` commands guarded with `|| true` — purely informational, never fails the build
- Replaces manual local `radon` invocations documented in the analysis guide

**Documentation Updates**
- Updated `docs/code-quality-analysis.md` with:
  - New "Type hints propagation" section detailing annotation strategy and module-by-module coverage
  - New "Mypy in CI" section explaining strict/permissive configuration and current status
  - New "Code quality metrics in CI" section documenting radon integration
  - Updated metrics table: type-annotated functions now at ~220 (was 36)
  - Marked items 14 (type hints + mypy) as done with branch reference

## Implementation Details

- Guidelines for propagation: preferred `Any` over guessing for backend objects; used `networkx.MultiDiGraph`, `pandas.DataFrame`, `Sequence[float]` for clear contracts; propagated abstract-base-class return types to concrete backends for Liskov-style checks
- Mutable defaults were not rewritten in this pass (tracked separately)
- `ignore_missing_imports = True` silences stubs from grid2op, lightsim2grid, networkx, rustworkx, pypowsybl
- `follow_imports = silent` prevents permissive run from cascading into strict-scope errors

https://claude.ai/code/session_0173Le82Tq8axHhYJWfEBCgD