### PR TITLE
Refactor: Split graphsAndPaths monolith into focused graphs package

### DIFF
--- a/alphaDeesp/core/graphs/__init__.py
+++ b/alphaDeesp/core/graphs/__init__.py
@@ -1,33 +1,34 @@
-"""Backwards-compatible shim for :mod:`alphaDeesp.core.graphsAndPaths`.
+"""alphaDeesp.core.graphs package.
 
-The original monolithic module has been split into the focused package
-:mod:`alphaDeesp.core.graphs`. All public names are re-exported here so
-existing imports such as::
-
-    from alphaDeesp.core.graphsAndPaths import OverFlowGraph, ConstrainedPath
-
-continue to work unchanged. New code should prefer importing directly
-from :mod:`alphaDeesp.core.graphs` (or one of its sub-modules).
+Public surface re-exports everything the legacy ``graphsAndPaths`` module
+used to expose. Existing import paths keep working through the shim in
+:mod:`alphaDeesp.core.graphsAndPaths`.
 """
 
-from alphaDeesp.core.graphs import (  # noqa: F401
-    ConstrainedPath,
-    OverFlowGraph,
-    PowerFlowGraph,
-    Structured_Overload_Distribution_Graph,
-    add_double_edges_null_redispatch,
+from alphaDeesp.core.graphs.constants import default_voltage_colors
+from alphaDeesp.core.graphs.graph_utils import (
     all_simple_edge_paths_multi,
-    default_voltage_colors,
     delete_color_edges,
     find_multidigraph_edges_by_name,
     from_edges_get_nodes,
     incident_edges,
     nodepath_to_edgepath,
+)
+from alphaDeesp.core.graphs.null_flow import (
+    add_double_edges_null_redispatch,
     remove_unused_added_double_edge,
+)
+from alphaDeesp.core.graphs.shortest_paths import (
     shortest_path_mandatory_and_promoted,
     shortest_path_min_weight_then_hops,
     shortest_path_with_promoted_edges,
 )
+from alphaDeesp.core.graphs.power_flow_graph import PowerFlowGraph
+from alphaDeesp.core.graphs.constrained_path import ConstrainedPath
+from alphaDeesp.core.graphs.structured_overload_graph import (
+    Structured_Overload_Distribution_Graph,
+)
+from alphaDeesp.core.graphs.overflow_graph import OverFlowGraph
 
 __all__ = [
     "default_voltage_colors",

--- a/alphaDeesp/core/graphs/constants.py
+++ b/alphaDeesp/core/graphs/constants.py
@@ -1,0 +1,13 @@
+"""Shared constants for the graphs package."""
+
+default_voltage_colors = {
+    400: "red",
+    225: "darkgreen",
+    90: "gold",
+    63: "purple",
+    20: "pink",
+    24: "pink",
+    15: "pink",
+    10: "pink",
+    33: "pink",
+}

--- a/alphaDeesp/core/graphs/constrained_path.py
+++ b/alphaDeesp/core/graphs/constrained_path.py
@@ -1,0 +1,75 @@
+"""ConstrainedPath: main path carrying overloaded lines."""
+
+import logging
+from typing import Any, List
+
+from alphaDeesp.core.graphs.graph_utils import from_edges_get_nodes
+
+logger = logging.getLogger(__name__)
+
+
+class ConstrainedPath:
+
+    """
+    A connected path of lines that includes the overloaded lines and for which the overflow redipsatch is negative.
+    This can be regarded as the main path through which the flows get in and out of the overloaded lines.
+    Hence flows should be pushed on other path to relieve the overloads.
+    """
+
+    def __init__(self, amont_edges: List[Any], constrained_edge: Any, aval_edges: List[Any]) -> None:
+        logger.debug("Constrained path created")
+        self.amont_edges = amont_edges #lines which flow goes into the overloaded lines
+        self.constrained_edge = constrained_edge #overloaded lines
+        self.aval_edges = aval_edges #lines which flow comes from the overloaded lines
+
+    def n_amont(self) -> list:
+        """Returns a list of nodes that are in "amont" """
+        return from_edges_get_nodes(self.amont_edges, "amont", self.constrained_edge)
+
+    def n_aval(self) -> List[Any]:
+        """Returns a list of nodes that are in "aval" """
+        return from_edges_get_nodes(self.aval_edges, "aval", self.constrained_edge)
+
+    def e_amont(self) -> List[Any]:
+        """Returns a list of edges that are in "amont" """
+        return self.amont_edges
+
+    def e_aval(self) -> List[Any]:
+        """Returns a list of edges that are in "aval" """
+        return self.aval_edges
+
+    def filter_constrained_path_for_nodes(self) -> List[Any]:
+        """
+        This filters the constrained_path_lists and creates a uniq ordered list that represents the constrained_path
+
+        Returns
+        ----------
+
+        res: ``array`` int
+            ordered list of nodes on the constrained path
+
+        """
+        set_constrained_path = []
+        for path in [self.amont_edges, self.constrained_edge, self.aval_edges]:
+            if isinstance(path, tuple):
+                edge = path
+                for n in edge[0:2]:
+                    if n not in set_constrained_path:
+                        set_constrained_path.append(n)
+            else:
+                for edge in path:
+                    if isinstance(edge, tuple):
+                        for n in edge[0:2]:
+                            if n not in set_constrained_path:
+                                set_constrained_path.append(n)
+
+        return set_constrained_path
+
+    def full_n_constrained_path(self) -> List[Any]:
+        return self.filter_constrained_path_for_nodes()
+
+    def __repr__(self) -> str:
+        return "################################################################\n" \
+               "ConstrainedPath = %s \nDetails: (amont: %s, constrained_edge: %s, aval: %s)\n" \
+               "################################################################" % (
+                   self.full_n_constrained_path(), self.amont_edges, self.constrained_edge, self.aval_edges)

--- a/alphaDeesp/core/graphs/graph_utils.py
+++ b/alphaDeesp/core/graphs/graph_utils.py
@@ -1,0 +1,148 @@
+"""Pure graph helper functions shared across the graphs package.
+
+These helpers operate directly on NetworkX graphs and do not depend on
+any of the graph *classes* defined in the package, which makes them
+trivial to unit-test in isolation.
+"""
+
+import logging
+from typing import Any, Iterable, List, Optional, Tuple
+
+import networkx as nx
+
+logger = logging.getLogger(__name__)
+
+
+def from_edges_get_nodes(edges: Iterable[Any], amont_or_aval: str, constrained_edge: Any) -> List[Any]:
+    """edges is a list of tuples"""
+    if edges:
+        nodes = []
+        for e in edges:
+            for node in e[:2]:
+                if node not in nodes:
+                    nodes.append(node)
+        return nodes
+    elif amont_or_aval == "amont":
+        return [constrained_edge[0]]
+    elif amont_or_aval == "aval":
+        return [constrained_edge[1]]
+    else:
+        raise ValueError("Error in function from_edges_get_nodes")
+
+def delete_color_edges(_g: nx.MultiDiGraph, edge_color: str) -> nx.MultiDiGraph:
+    """
+    Returns a copy of a graph without edges of a given color. Gray for instance, with values below a threshold of significance
+
+    From a given node, get blue edges (with negative overflow redispatch) that are above this node
+
+    Parameters
+    ----------
+
+    _g: :class:`nx:MultiDiGraph`
+        an overflow redispatch networkx graph
+
+    edge_color: ``str``
+        color of edges to delete from graoh
+
+    Returns
+    ----------
+
+    res: :class:`nx:MultiDiGraph`
+        the graph without edges for the targeted color
+
+    """
+    g = _g.copy()
+
+    TargetColor_edges = []
+    i = 1
+    for u, v,idx, color in g.edges(data="color",keys=True):
+        if color == edge_color:
+            TargetColor_edges.append((i, (u, v,idx)))
+        i += 1
+
+    # delete from graph gray edges
+    # this extracts the (u,v) from pos_edges
+    if TargetColor_edges:
+        g.remove_edges_from(list(zip(*TargetColor_edges))[1])
+        g.remove_nodes_from(list(nx.isolates(g)))
+    return g
+
+def nodepath_to_edgepath(G: Any, node_path: List[Any], with_keys: bool = False) -> List[Any]:
+    """Convert a list of nodes into a list of edges for Graph/MultiGraph."""
+    edges = []
+    for u, v in zip(node_path[:-1], node_path[1:]):
+        if with_keys and G.is_multigraph():
+            # take the first key by default
+            #k = next(iter(G[u][v].keys()))
+            #take all keys
+            for k in G[u][v].keys():
+                edges.append((u, v, k))
+        else:
+            edges.append((u, v))
+    return edges
+
+def incident_edges(G: Any, node: Any, data: bool = True, keys: bool = False) -> List[Any]:
+    if keys and G.is_multigraph():
+        out_e = G.out_edges(node, keys=True, data=data)
+        in_e  = G.in_edges(node, keys=True, data=data)
+    else:
+        out_e = G.out_edges(node, data=data)
+        in_e  = G.in_edges(node, data=data)
+    return list(out_e) + list(in_e)
+
+def all_simple_edge_paths_multi(G: Any, sources: Iterable[Any], targets: Iterable[Any], cutoff: Optional[int] = None) -> Any:
+    """
+    Yield all simple edge paths between multiple sources and targets.
+
+    Parameters
+    ----------
+    G : nx.Graph / nx.DiGraph / nx.MultiDiGraph
+        Graph object.
+    sources : iterable
+        Set/list of source nodes.
+    targets : iterable
+        Set/list of target nodes.
+    cutoff : int, optional
+        Maximum path length.
+
+    Yields
+    ------
+    path : list of edges (u, v) or (u, v, key) for multigraphs
+    """
+    for s in sources:
+        for t in targets:
+            if s != t and s in G and t in G:
+                try:
+                    for path in nx.all_simple_edge_paths(G, s, t, cutoff=cutoff):
+                        yield path
+                except nx.NetworkXNoPath:
+                    continue
+
+def find_multidigraph_edges_by_name(G: nx.MultiDiGraph, source_node: Any, target_names: Iterable[Any], depth: int = 2, name_attr: str = "name") -> List[Any]:
+    """
+    Traverses the MultiDiGraph using BFS up to 'depth'.
+    For every connection (u, v) traversed, checks ALL parallel edges
+    to see if their name is in 'target_names'.
+    """
+    # 1. Optimization: Set for O(1) lookup
+    target_set = set(target_names)
+    found_edges = []
+
+    # 2. Lazy BFS Traversal
+    # nx.bfs_edges yields (u, v) pairs representing the discovery path.
+    # It yields (u, v) exactly once, even if there are multiple edges.
+    for u, v in nx.bfs_edges(G, source_node, depth_limit=depth):
+
+        # 3. Inspect ALL parallel edges between u and v
+        # G[u][v] returns a dictionary of keys: {key1: {attr...}, key2: {attr...}}
+        if G.has_edge(u, v):
+            parallel_edges = G[u][v]
+
+            for key, attributes in parallel_edges.items():
+                edge_name = attributes.get(name_attr)
+
+                # Check if this specific line is in our target list
+                if edge_name in target_set:
+                    found_edges.append(edge_name)
+
+    return found_edges

--- a/alphaDeesp/core/graphs/null_flow.py
+++ b/alphaDeesp/core/graphs/null_flow.py
@@ -1,0 +1,90 @@
+"""Double / un-double null-flow edges in an overflow graph."""
+
+from typing import Any, Dict, Set, Tuple
+
+import networkx as nx
+
+
+def remove_unused_added_double_edge(g: nx.MultiDiGraph, edges_to_keep: Set[Any], edges_to_double: Dict[Any, Any], edges_double_added: Dict[Any, Any]) -> nx.MultiDiGraph:
+
+    """
+    Make edges bi-directionnal when flow redispatch value is null
+
+    Parameters
+    ----------
+     g: NetworkX graph
+      graph on which to remove edges
+     edges_to_keep: ``set`` str
+        set of edges of interest found on paths and to be recoloured
+
+    edges_to_double: ``dict`` str: networkx edge
+        original set of edges that has been doubled, with line names as key and edge as value
+
+    edges_double_added: ``dict`` str: networkx edge
+        new set of edges that doubles the original ones in the other direction, with line name as key and edge as value
+
+    Return
+    ----------------
+    g: NetworkX graph
+      graph on which edges where removed
+    """
+    # Get names of kept edges directly (replaces edge_subgraph creation)
+    name_edges_to_keep = set()
+    for edge in edges_to_keep:
+        name = g.edges[edge].get("name") if g.has_edge(*edge) else None
+        if name is not None:
+            name_edges_to_keep.add(name)
+
+    # for initial edges that has not been recoloured but for which the added double edge has been, remove those initial edges
+    edges_to_remove = []
+    edge_names_to_remove = set()
+    for name, edge in edges_to_double.items():
+        if name in name_edges_to_keep and g.edges[edge]["color"] == "gray":
+            edges_to_remove.append(edge)
+            edge_names_to_remove.add(name)
+
+    # for added double edges that has not been recoloured, remove them
+    edges_to_remove += [edge for name, edge in edges_double_added.items() if name not in edge_names_to_remove]
+    assert (len(edges_to_remove) == len(edges_to_double))
+    g.remove_edges_from(edges_to_remove)
+
+    return g
+
+def add_double_edges_null_redispatch(g: nx.MultiDiGraph, color_init: str = "gray", only_no_dir: bool = False) -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
+    """
+    Make edges bi-directionnal when flow redispatch value is null
+
+    Parameters
+    -------------
+    g: NetworkX graph
+      graph on which to add edges
+
+    only_no_dir: bool
+        condition to restrict edge doubling at no_dir case
+
+    Returns
+    ----------
+    edges_to_double_name_dict: ``dict`` str: networkx edge
+        original set of edges that has been doubled, with line names as key and edge as value
+
+    edges_added_name_dict: ``dict`` str: networkx edge
+        new set of edges that doubles the original ones in the other direction, with line name as key and edge as value
+
+    """
+    # Single pass over edges to find those to double (replaces 4 nx.get_edge_attributes calls)
+    to_double = []
+    edges_to_double_name_dict = {}
+    for u, v, k, data in g.edges(keys=True, data=True):
+        if data.get("color") == color_init and data.get("capacity") == 0.:
+            if not only_no_dir or "dir" in data:
+                to_double.append((u, v, k, data))
+                edges_to_double_name_dict[data["name"]] = (u, v, k)
+
+    # Add reverse edges and directly track new edge keys
+    edges_added_name_dict = {}
+    for u, v, k, data in to_double:
+        new_key = g.add_edge(v, u, **data)
+        edges_added_name_dict[data["name"]] = (v, u, new_key)
+
+    assert(set(edges_to_double_name_dict.keys())==set(edges_added_name_dict.keys()))
+    return edges_to_double_name_dict,edges_added_name_dict

--- a/alphaDeesp/core/graphs/overflow_graph.py
+++ b/alphaDeesp/core/graphs/overflow_graph.py
@@ -1,0 +1,1284 @@
+"""OverFlowGraph: coloured overflow-redispatch graph.
+
+Subclasses :class:`PowerFlowGraph`. Most of the mass of the original
+``graphsAndPaths`` monolith lived here: this module keeps the class body
+identical while delegating helpers and the structured-graph builder to
+sibling modules.
+"""
+
+import logging
+from math import fabs
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+from alphaDeesp.core.printer import Printer
+from alphaDeesp.core.graphs.power_flow_graph import PowerFlowGraph
+from alphaDeesp.core.graphs.structured_overload_graph import (
+    Structured_Overload_Distribution_Graph,
+)
+from alphaDeesp.core.graphs.graph_utils import (
+    all_simple_edge_paths_multi,
+    delete_color_edges,
+    find_multidigraph_edges_by_name,
+    nodepath_to_edgepath,
+)
+from alphaDeesp.core.graphs.null_flow import (
+    add_double_edges_null_redispatch,
+    remove_unused_added_double_edge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OverFlowGraph(PowerFlowGraph):
+    """
+    A coloured graph of grid overflow redispatch, displaying the delta flows before and after disconnecting the overloaded lines
+    """
+
+    def __init__(self, topo: Dict[str, Any], lines_to_cut: List[int], df_overflow: pd.DataFrame, layout: Optional[List[Tuple[float, float]]] = None, float_precision: str = "%.2f") -> None:
+        """
+        Parameters
+        ----------
+
+        topo: :class:`dict`
+            dictionnary of two dictionnaries edges and nodes, to represent the grid topologie. edges have attributes "init_flows" representing the power flowing, as well as "idx_or","idx_ex"
+             for substation extremities
+             Nodes have attributes "are_prods","are_loads" if nodes have any productions or any load, as well as "prods_values","load_values" array enumerating the prod and load values at this node.
+
+        lines_to_cut: ``array``
+            ids of lines disconnected
+
+        df_overflow: :class:``pd.Dataframe``
+            pandas dataframe of deltaflows after disconnecting the overloaded lines. see create_df in simulation.py. One row per powerline
+            columns: idx_or, idx_ex, init_flows, new_flows, delta_flows, gray_edges (for unsignificant delta_flows below a threshold)
+
+        """
+        if "line_name" not in df_overflow.columns:
+            df_overflow["line_name"]=[str(idx_or)+"_"+str(idx_ex)+"_"+str(i) for i, (idx_or,idx_ex) in df_overflow[["idx_or","idx_ex"]].iterrows()]
+
+        self.df = df_overflow
+        super().__init__(topo, lines_to_cut,layout,float_precision)
+
+    def build_graph(self) -> None:
+        """This method creates the NetworkX Graph of the overflow redispatch """
+        g = nx.MultiDiGraph()
+        self.build_nodes(g, self.topo["nodes"]["are_prods"], self.topo["nodes"]["are_loads"],
+                    self.topo["nodes"]["prods_values"], self.topo["nodes"]["loads_values"])
+
+        self.build_edges_from_df(g, self.lines_cut)
+
+        # print("WE ARE IN BUILD GRAPH FROM DATA FRAME ===========")
+        # all_edges_label_attributes = nx.get_edge_attributes(g, "label")  # dict[edge]
+        # print("all_edges_label_attributes = ", all_edges_label_attributes)
+
+        self.g=g
+        #self.add_double_edges_null_redispatch()
+
+    def build_edges_from_df(self, g: nx.MultiDiGraph, lines_to_cut: List[int]) -> None:
+        """
+        Create edges in graph for overflow redispatch
+
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            a networkx graph to which to add edges
+
+        lines_to_cut: ``array`` int
+            list of lines in overflow that are getting disconnected
+
+        """
+
+        i = 0
+        max_abs_flow = self.df["delta_flows"].abs().max()
+        target_max_penwidth = 15.0
+        # Determine the scaling factor
+        if max_abs_flow > 0:
+            scaling_factor = target_max_penwidth / max_abs_flow
+        else:
+            scaling_factor = 1.0
+
+        for origin, extremity, reported_flow, gray_edge, line_name in zip(self.df["idx_or"], self.df["idx_ex"],
+                                                               self.df["delta_flows"], self.df["gray_edges"],self.df["line_name"]):
+            penwidth = fabs(reported_flow) * scaling_factor
+            min_penwidth=0.1
+            if penwidth == 0.0:
+                penwidth = min_penwidth
+            if i in lines_to_cut:
+                g.add_edge(origin, extremity, capacity=float(self.float_precision % reported_flow), label=self.float_precision % reported_flow,
+                           color="black", fontsize=10, penwidth=max(float(self.float_precision % penwidth),min_penwidth),
+                           constrained=True, name=line_name)#style="dotted, setlinewidth(2)"
+            elif gray_edge:  # Gray
+                g.add_edge(origin, extremity, capacity=float(self.float_precision % reported_flow), label=self.float_precision % reported_flow,
+                           color="gray", fontsize=10, penwidth=max(float(self.float_precision % penwidth),min_penwidth),name=line_name)
+            elif reported_flow < 0:  # Blue
+                g.add_edge(origin, extremity, capacity=float(self.float_precision % reported_flow), label=self.float_precision % reported_flow,
+                           color="blue", fontsize=10, penwidth=max(float(self.float_precision % penwidth),min_penwidth),name=line_name)
+            else:  # > 0  # Red
+                g.add_edge(origin, extremity, capacity=float(self.float_precision % reported_flow), label=self.float_precision % reported_flow,
+                           color="coral",#orange"#ff8000"#"coral",
+                           fontsize=10, penwidth=max(float(self.float_precision % penwidth),min_penwidth),name=line_name)#"#ff8000")#orange
+            i += 1
+        #nx.set_edge_attributes(g, {e:self.df["line_name"][i] for i,e in enumerate(g.edges)}, name="name")
+
+    def keep_overloads_components(self) -> None:
+        """
+        Filter the graph to only keep components that contain overloaded (black) edges.
+
+        For the coloured graph (graph without grey edges), detect connected components
+        that do not include any overloaded edges (black colour) and recolour all their
+        edges to grey so they are no longer considered significant.
+        """
+        # Build the coloured graph: remove grey edges to get only significant ones
+        g_coloured = delete_color_edges(self.g, "gray")
+
+        # Find weakly connected components of the coloured graph
+        components = list(nx.weakly_connected_components(g_coloured))
+
+        for component_nodes in components:
+            # Get the subgraph for this component
+            subgraph = g_coloured.subgraph(component_nodes)
+
+            # Check if the component contains any black (overloaded) edge
+            has_overload = any(
+                color == "black"
+                for _, _, color in subgraph.edges(data="color")
+            )
+
+            if not has_overload:
+                # Recolour all edges of this component to grey in the original graph
+                for u, v, key in self.g.edges(keys=True):
+                    if u in component_nodes and v in component_nodes:
+                        if self.g[u][v][key].get("color") != "gray":
+                            self.g[u][v][key]["color"] = "gray"
+
+    def consolidate_constrained_path(self, constrained_path_nodes_amont: List[Any], constrained_path_nodes_aval: List[Any], constrained_path_edges: List[Any], ignore_null_edges: bool = True) -> None:  # hub_sources,hub_targets):
+        """
+        Consolidate constrained blue path for some edges that were discarded with lower values but are actually on the path
+        knowing the hubs in the SuscturedOverflowGraph
+
+        Parameters
+        ----------
+
+        hub_sources: ``array``
+            list of nodes that are hubs and sources of loop paths in the structured graph
+
+        hub_targets: ``array``
+            list of nodes that are hubs and targets of loop paths in the structured graph
+
+        """
+        all_edges_to_recolor = []
+
+        # we capture all edges with negative value that we find in between the two hubs (source and target)
+        # this is important for graphs with double or triple edges for instance between nodes
+        g_to_consolidate=delete_color_edges(self.g, "coral")
+
+        if ignore_null_edges:
+            init_capacity = nx.get_edge_attributes(g_to_consolidate, "capacity")
+            edges_to_remove_null_capacity = [edge for edge, capacity in
+                                     init_capacity.items() if capacity ==0. ]
+            g_to_consolidate.remove_edges_from(edges_to_remove_null_capacity)
+
+        g_to_consolidate.remove_edges_from(constrained_path_edges)
+
+        g_to_consolidate_amont=g_to_consolidate.copy()
+        g_to_consolidate_amont.remove_nodes_from(constrained_path_nodes_aval)#we don't want to look at paths that goes through aval nodes
+
+        g_to_consolidate_aval=g_to_consolidate
+        g_to_consolidate_aval.remove_nodes_from(constrained_path_nodes_amont)#we don't want to look at paths that goes through amont nodes
+
+        list_g_to_consolidate=[g_to_consolidate_amont,g_to_consolidate_aval]
+        list_nodes_constrainted_path=[constrained_path_nodes_amont,constrained_path_nodes_aval]
+
+        all_edges_to_recolor=[]
+        for g_c,node_sources in zip(list_g_to_consolidate,list_nodes_constrainted_path):
+            paths = list(all_simple_edge_paths_multi(g_c, node_sources, node_sources))
+            current_colors = nx.get_edge_attributes(g_c, 'color')
+            if len(paths)!=0:
+                for path in paths:
+                    path_color = set([current_colors[edge] for edge in path])
+                    has_edge_to_recolor=len(path_color - set({"blue","black"}))!=0
+                    if has_edge_to_recolor:
+                        all_edges_to_recolor += path
+
+                all_edges_to_recolor=set(all_edges_to_recolor)
+
+                edge_attribues_to_set = {edge: {"color": "blue"} for edge in all_edges_to_recolor if current_colors[edge] not in ["blue","black"]}
+                nx.set_edge_attributes(self.g, edge_attribues_to_set)
+
+
+
+        #g_without_pos_edges = delete_color_edges(self.g, "coral")
+        #current_colors = nx.get_edge_attributes(self.g, 'color')
+#
+        #init_capacity = nx.get_edge_attributes(g_without_pos_edges, "capacity")
+        #edges_to_remove_positive_capacity = [edge for edge, capacity in
+        #                             init_capacity.items() if capacity >0. ]
+        #g_without_pos_edges.remove_edges_from(edges_to_remove_positive_capacity)
+
+        #Reasoning flawed in the end, we don't want to fin new contsrained path from amont to aval of the constraint, but only amont and only aval
+        #for source, target in zip(hub_sources, hub_targets):
+        #    paths = nx.all_simple_edge_paths(g_without_pos_edges, source, target)
+#
+        #    for path in paths:
+        #        path_color = set([current_colors[edge] for edge in path])
+        #        has_edge_to_recolor=len(path_color - set({"blue","black"}))!=0
+        #        if has_edge_to_recolor:
+        #            all_edges_to_recolor += path
+#
+        #all_edges_to_recolor=set(all_edges_to_recolor)
+#
+#
+        #current_weights=nx.get_edge_attributes(self.g, 'capacity') #############################
+        #edge_attribues_to_set = {edge: {"color": "blue"} for edge in all_edges_to_recolor if current_colors[edge] not in ["blue","black"] and float(current_weights[edge])!=0}
+        #nx.set_edge_attributes(self.g, edge_attribues_to_set)
+#
+        ##########
+        ##correction: reverse edges with positive values
+        #current_capacities = nx.get_edge_attributes(self.g, 'capacity')
+        #edges_to_correct=[edge for edge in all_edges_to_recolor if current_capacities[edge]>0]
+        #reverse_edges=[(edge_ex,edge_or,edge_properties) for edge_or,edge_ex,edge_properties in self.g.edges(data=True) if edge_properties["color"]=="blue" and edge_properties["capacity"]>0]
+        #self.g.add_edges_from(reverse_edges)
+        #self.g.remove_edges_from(edges_to_correct)
+#
+        ##correct capacity values with opposite value after reversing edge
+        #current_capacities = nx.get_edge_attributes(self.g, 'capacity')
+        #current_colors = nx.get_edge_attributes(self.g, 'color')
+        #edge_attribues_to_set = {edge: {"capacity": -capacity,"label":str(-capacity)}
+        #                         for edge,color,capacity in zip(self.g.edges,current_colors.values(),current_capacities.values()) if
+        #                         capacity>0 and color=="blue"}
+        #nx.set_edge_attributes(self.g, edge_attribues_to_set)
+
+        ############
+        #for null flow redispatch, if connected to nodes on blue path, reverse it and make it blue for it to belong there
+        #blue_edges=[edge for edge in self.g.edges if current_colors[edge]=="blue"]
+        #nodes_blue_path=self.g.edge_subgraph(blue_edges).nodes
+
+        #overall_constrained_graph=self.g.subgraph(nodes_constrained_path)
+#
+        #current_capacities = nx.get_edge_attributes(overall_constrained_graph, 'capacity')
+        #current_colors = nx.get_edge_attributes(overall_constrained_graph, 'color')
+#
+        #edges_non_constrained_path_yet=[edge for edge,color in current_colors.items() if color not in ["blue","black"]]
+        #edges_non_constrained_path_yet_with_properties=[(edge_or,edge_ex,edge_properties) for edge_or,edge_ex,edge_properties in overall_constrained_graph.edges(data=True) if edge_properties["color"] not in ["blue","black"]]
+#
+        #if len(edges_non_constrained_path_yet)!=0:
+        #    #reverse edges for red edges
+        #    edges_to_correct=[edge for edge,capacity in current_capacities.items() if capacity>0]
+        #    reverse_edges=[(edge_ex,edge_or,edge_properties) for edge_or,edge_ex,edge_properties in edges_non_constrained_path_yet_with_properties if edge_properties["capacity"]>0]
+        #    self.g.add_edges_from(reverse_edges)
+        #    self.g.remove_edges_from(edges_to_correct)
+#
+        #    #update of this after reversing edges
+        #    overall_constrained_graph=self.g.subgraph(nodes_constrained_path)
+        #    current_colors = nx.get_edge_attributes(overall_constrained_graph, 'color')
+        #    current_capacities = nx.get_edge_attributes(overall_constrained_graph, 'capacity')
+        #    edges_non_constrained_path_yet = [edge for edge, color in current_colors.items() if
+        #                                      color not in ["blue", "black"]]
+#
+        #    #set new attribute, in particular blue color
+        #    edge_attributes_to_set = {edge: {"capacity": -abs(current_capacities[edge]),"label":str(-abs(current_capacities[edge])),"color":"blue"}
+        #                             for edge in edges_non_constrained_path_yet}
+        #    nx.set_edge_attributes(self.g, edge_attributes_to_set)
+#
+        #print("ok")
+
+    def reverse_edges(self, edge_path_names: List[str], target_color: str) -> None:
+
+        graph_adge_names = nx.get_edge_attributes(self.g, 'name')
+        edges_path=[edge for edge, name in graph_adge_names.items() if name in edge_path_names]
+
+        path_subgraph = self.g.edge_subgraph(edges_path)
+        current_colors = nx.get_edge_attributes(path_subgraph, 'color')
+
+        if target_color == "coral":
+            new_colors = {e: {"color": "coral"} for e, color
+                          in current_colors.items()}
+        else:
+            new_colors = {e: {"color": "blue"} for e, color
+                          in current_colors.items()}
+        nx.set_edge_attributes(self.g, new_colors)
+        # reversing capacities (with negative values) and direction for edges for which we changed color
+        reduced_capacities_dict = nx.get_edge_attributes(path_subgraph, "capacity")
+        new_attributes_dict = {e: {"capacity": -capacity, "label": self.float_precision % -capacity} for e, capacity
+                               in reduced_capacities_dict.items() if current_colors[e]!=target_color}
+        nx.set_edge_attributes(self.g, new_attributes_dict)
+
+        edges_to_reverse=list(new_attributes_dict.keys())
+        path_subgraph_to_reverse = path_subgraph.edge_subgraph(edges_to_reverse)
+        self.g.add_edges_from([(edge[1], edge[0], edge[2]) for edge in path_subgraph_to_reverse.edges(data=True)])
+        self.g.remove_edges_from(edges_to_reverse)
+
+    def reverse_blue_edges_in_looppaths(self, constrained_path: List[Any]) -> None:
+        """
+        Reverse blue edges that are not on the constrained paths, and that should be regarded as edges on which we are pushing
+        the flows
+
+        Parameters
+        ----------
+
+        constrained_path: ``list``
+            list of nodes that areon the constrained path
+
+        """
+        g_without_pos_edges = delete_color_edges(self.g, "coral")
+        #g_only_blue_components = delete_color_edges(g_without_pos_edges, "gray")
+        #g_only_blue_components.remove_nodes_from(constrained_path)
+        g_without_pos_edges.remove_nodes_from(constrained_path)
+
+        #edges that have positive capacities, and significant enough (more than 1MW delta_flow) among gray edges should not be touched
+        capacities_dict = nx.get_edge_attributes(g_without_pos_edges, "capacity")
+        g_without_pos_edges.remove_edges_from([edge for edge,capacity in capacities_dict.items() if capacity>-1])
+
+        #modifies blue edges (reverse them and color them red) that are not on constrained path
+        #on the graph
+        #changing colors only for significative flows (non gray) here
+        current_colors = nx.get_edge_attributes(g_without_pos_edges, 'color')
+
+        new_colors = {e: {"color": "coral"} for e, color
+                               in current_colors.items() if color!="gray"}
+        nx.set_edge_attributes(g_without_pos_edges, new_colors)
+
+        # reversing capacities (with negative values) and direction for all edges here
+        reduced_capacities_dict = nx.get_edge_attributes(g_without_pos_edges, "capacity")
+        new_attributes_dict = {e: {"capacity": -capacity, "label": self.float_precision % -capacity} for e, capacity
+                               in reduced_capacities_dict.items() if capacity!=0}
+        nx.set_edge_attributes(g_without_pos_edges, new_attributes_dict)
+
+        self.g.add_edges_from([(edge[1], edge[0], edge[2]) for edge in g_without_pos_edges.edges(data=True)])
+        self.g.remove_edges_from(g_without_pos_edges.edges)
+
+    def consolidate_loop_path(self, hub_sources: Iterable[Any], hub_targets: Iterable[Any], ignore_null_edges: bool = True) -> None:
+        """
+        Consolidate constrained red path for some edges that were discarded with lower values but are actually on the path
+        knowing the hubs in the SuscturedOverflowGraph
+        WARNING: prefer to reverse blue edges first with reverse_blue_edges_in_looppaths, to get a better result
+
+        Parameters
+        ----------
+
+        hub_sources: ``array``
+            list of nodes that are hubs and sources of loop paths in the structured graph
+
+        hub_targets: ``array``
+            list of nodes that are hubs and targets of loop paths in the structured graph
+
+        """
+        all_edges_to_recolor = []
+
+        # we capture all edges with negative value that we find in between the two hubs (source and target)
+        # this is important for graphs with double or triple edges for instance between nodes
+        g_without_blue_edges = delete_color_edges(self.g, "blue")
+
+        if ignore_null_edges:
+            init_capacity = nx.get_edge_attributes(g_without_blue_edges, "capacity")
+            edges_to_remove_null_capacity = [edge for edge, capacity in
+                                         init_capacity.items() if capacity == 0.]
+            g_without_blue_edges.remove_edges_from(edges_to_remove_null_capacity)
+
+        for source, target in zip(hub_sources, hub_targets):
+            paths = nx.all_simple_edge_paths(g_without_blue_edges, source, target)
+            for path in paths:
+                all_edges_to_recolor += path
+
+        all_edges_to_recolor=set(all_edges_to_recolor)
+
+        current_colors = nx.get_edge_attributes(self.g, 'color')
+        #all_edges_to_recolor=
+        edge_attribues_to_set = {edge: {"color": "coral"} for i,edge in enumerate(g_without_blue_edges.edges) if edge in all_edges_to_recolor and current_colors[edge]=="gray"}
+        nx.set_edge_attributes(self.g, edge_attribues_to_set)
+
+    def set_hubs_shape(self, hubs: Iterable[Any], shape_hub: str = "circle") -> None:
+        """
+        Distinguish the shape of "hub" nodes to make them more visible
+
+        Parameters
+        ----------
+
+        hub: ``array``
+            list of nodes that are hubs in the structured graph
+
+        shape_hub: ``str``
+            shape type for drawing the hubs
+        """
+        dict_shapes = {node: "oval" for node in self.g.nodes}
+        for hub in hubs:
+            dict_shapes[hub] = shape_hub
+
+        nx.set_node_attributes(self.g, dict_shapes, "shape")
+
+    def highlight_swapped_flows(self, lines_swapped: List[Any]) -> None:
+        """
+        Highlight lines with "tappered" style on edge that have seen their flows swapped in the overflow graph to be aware of that
+
+        Parameters
+        ----------
+
+        lines_swapped: ``list``
+            list of lines whose flow direction has swapped
+
+        """
+        edge_names = nx.get_edge_attributes(self.g, "name")
+        edge_styles={edge:"tapered" for edge, edge_name in edge_names.items() if edge_name in lines_swapped}
+        edge_dirs = {edge: "both" for edge, edge_name in edge_names.items() if edge_name in lines_swapped}
+        edge_tails = {edge: "none" for edge, edge_name in edge_names.items() if edge_name in lines_swapped}
+
+        nx.set_edge_attributes(self.g, edge_styles, "style")
+        nx.set_edge_attributes(self.g, edge_dirs, "dir")
+        nx.set_edge_attributes(self.g, edge_tails, "arrowtail")
+
+    def highlight_significant_line_loading(self, dict_line_loading: Dict[Any, Any]) -> None:
+        """
+        Highlight lines that could get overloaded and should be monitored. Edge label is augmented with change in loading rate
+        before and after the constrained line cut
+
+        WARNING: apply this at the end of the process before ploting the graph, as it changes the edge colors for these target lines,
+        but colors are used in other part of the processing and if they are change before, this could create interferences
+
+        Parameters
+        ----------
+
+        dict_line_loading: ``dict``
+            dict of lines to monitor with "before" and "after" loading rate values
+
+        """
+        edge_names = nx.get_edge_attributes(self.g, "name")
+        edge_colors = nx.get_edge_attributes(self.g, "color")
+        edge_x_labels = nx.get_edge_attributes(self.g, "label")
+        label_font_color = {edge: "black" for edge in edge_names.keys()}
+        color_label_highlight = "darkred"  # "gold"
+
+        for edge, edge_name in edge_names.items():
+            if edge_name in dict_line_loading:
+                current_x_lable = edge_x_labels[edge]
+                current_edge_color = edge_colors[edge]
+
+                # update edge labels for loaded lines with loading change
+                if current_edge_color == "black":  # this is a constraint, highlight initial overloading rate
+                    edge_x_labels[
+                        edge] = f'< {current_x_lable} <BR/>  <B>{dict_line_loading[edge_name]["before"]}%</B>  → {dict_line_loading[edge_name]["after"]}%>'
+                else:
+                    edge_x_labels[
+                        edge] = f'< {current_x_lable} <BR/>  {dict_line_loading[edge_name]["before"]}% → <B>{dict_line_loading[edge_name]["after"]}%</B> >'
+
+                # update font color and edge color for highlighting
+                label_font_color[edge] = color_label_highlight
+                edge_colors[edge] = f'"{current_edge_color}:yellow:{current_edge_color}"'
+
+        # edge_x_label=[edge_x_label+"\n "+str(dict_line_loading[edge_name["before"]])+"% -> "+str(dict_line_loading[edge_name["after"]])+"%" else edge_x_label for edge_name,edge_x_label in zip(edge_names,edge_x_label) if edge_name in dict_line_loading]
+        nx.set_edge_attributes(self.g, edge_x_labels, "label")
+        nx.set_edge_attributes(self.g, label_font_color, "fontcolor")
+        nx.set_edge_attributes(self.g, edge_colors, "color")
+
+    def plot(self, layout: Optional[List[Any]], rescale_factor: Optional[float] = None, allow_overlap: bool = True, fontsize: Optional[int] = None, node_thickness: int = 3, save_folder: str = "", without_gray_edges: bool = False) -> Any:
+        printer=Printer(save_folder)
+        g=self.g
+
+        if layout is not None:
+            layout_dict = {n: coord for n, coord in zip(g.nodes, layout)}
+
+        if without_gray_edges:
+            g=delete_color_edges(g, "gray")
+            kept_nodes=g.nodes
+
+            if layout is not None:
+                layout=[layout_dict[node] for node in kept_nodes]# for node, coord in layout_dict.items() if node in kept_nodes]
+
+        if save_folder=="":
+            output_graphviz_svg=printer.plot_graphviz(g, layout,rescale_factor=rescale_factor,allow_overlap=allow_overlap,fontsize=fontsize,node_thickness=node_thickness, name="g_overflow_print")
+            return output_graphviz_svg
+        else:
+            printer.display_geo(g, layout,rescale_factor=rescale_factor,fontsize=fontsize,node_thickness=node_thickness, name="g_overflow_print")
+            return None
+
+    def consolidate_graph(self, structured_graph: Any, non_connected_lines_to_ignore: List[Any] = [], no_desambiguation: bool = False) -> None:
+        """
+        Consolidate overflow graph knwoing structural elements from SuscturedOverflowGraph
+
+        Parameters
+        ----------
+
+        structured_graph: ``SuscturedOverflowGraph``
+            a structured graph with identified constrained path, hubs, loop paths
+
+        """
+        #remove temporarily edges
+        # Get the names of the edges in the graph
+        edge_names = nx.get_edge_attributes(self.g, 'name')
+        edges_to_remove = [edge for edge, edge_name in edge_names.items() if
+                           edge_name in non_connected_lines_to_ignore]
+#
+        edges_to_remove_data = [(edge_or, edge_ex, edge_properties) for edge_or, edge_ex, edge_properties in
+                                self.g.edges(data=True) if
+                                edge_properties["name"] in non_connected_lines_to_ignore]
+
+        self.g.remove_edges_from(edges_to_remove)
+
+        # consolider le chemin en contrainte avec la connaissance des hubs, en itérant une fois de plus
+        n_hubs_init = 0
+        hubs_paths = structured_graph.find_loops()[["Source", "Target"]].drop_duplicates()
+        n_hub_paths = hubs_paths.shape[0]
+
+        while n_hubs_init != n_hub_paths:
+            n_hubs_init = n_hub_paths
+
+            constrained_path = structured_graph.constrained_path
+            nodes_amont = constrained_path.n_amont()
+            nodes_aval = constrained_path.n_aval()
+            constrained_path_edges = constrained_path.aval_edges + [
+                constrained_path.constrained_edge] + constrained_path.amont_edges
+            self.consolidate_constrained_path(nodes_amont, nodes_aval, constrained_path_edges)
+
+            structured_graph = Structured_Overload_Distribution_Graph(self.g)
+
+            hubs_paths = structured_graph.find_loops()[["Source", "Target"]].drop_duplicates()
+            n_hub_paths = hubs_paths.shape[0]
+
+        #recolor and reverse blue or red edges outside of constrained or loop paths
+        if not no_desambiguation:
+            ambiguous_edge_paths, ambiguous_node_paths = self.identify_ambiguous_paths(structured_graph)
+            for ambiguous_edge_path, ambiguous_node_path in zip(ambiguous_edge_paths, ambiguous_node_paths):
+                path_type=self.desambiguation_type_path(ambiguous_node_path, structured_graph)
+                if path_type=="loop_path":
+                    self.reverse_edges(ambiguous_edge_path,target_color="coral")
+                else:
+                    self.reverse_edges(ambiguous_edge_path, target_color="blue")
+
+        #not needed anymore as more generic ambiguous path detection and correction above ?
+        #constrained_path = structured_graph.constrained_path.full_n_constrained_path()
+        #self.reverse_blue_edges_in_looppaths(constrained_path)
+
+        # consolidate loop paths by recoloring gray edges that are significant enough and within a loop path
+        self.consolidate_loop_path(hubs_paths.Source, hubs_paths.Target)
+
+        #add back removed edges
+        self.g.add_edges_from(edges_to_remove_data)
+
+    def identify_ambiguous_paths(self, structured_graph: Any) -> Tuple[List[Any], List[Any]]:
+        """
+        Identify ambiguous paths in the structured graph.
+
+        An ambiguous path is one that contains both red and blue edges. These paths need to be desambiguated
+        to determine which color (red or blue) should be kept for further analysis.
+
+        Parameters
+        ----------
+        structured_graph : Structured_Overload_Distribution_Graph
+            A structured graph with identified constrained path, hubs, loop paths.
+
+        Returns
+        -------
+        tuple
+            A tuple containing two lists:
+            - ambiguous_edge_paths: List of lists, where each inner list contains the names of edges in an ambiguous path.
+            - ambiguous_node_paths: List of sets, where each set contains the nodes in an ambiguous path.
+        """
+
+        # Get the graph without gray and constrained edges
+        g_red_blue_ambiguous = structured_graph.g_without_gray_and_c_edge
+
+        # Get the names of the edges in the graph
+        edge_names = nx.get_edge_attributes(structured_graph.g_without_gray_and_c_edge, 'name')
+
+        # Identify lines that are part of the constrained path and dispatch path
+        lines_constrained_path, nodes_constrained_path,other_blue_edges, other_blue_nodes  = structured_graph.get_constrained_edges_nodes()
+        lines_dispatch, nodes_dispatch_path = structured_graph.get_dispatch_edges_nodes()
+
+        # Remove edges that are part of the constrained path or dispatch path from the graph
+        edges_to_remove = [edge for edge, edge_name in edge_names.items() if
+                           edge_name in lines_constrained_path + lines_dispatch]
+        g_red_blue_ambiguous.remove_edges_from(edges_to_remove)
+
+        # Find weakly connected components in the graph
+        weak_comps = nx.weakly_connected_components(g_red_blue_ambiguous)
+
+        # Initialize lists to store ambiguous edge paths and node paths
+        ambiguous_edge_paths = []
+        ambiguous_node_paths = []
+
+        # Iterate over each weakly connected component
+        for c in weak_comps:
+            # If the component has at least two nodes, it is considered ambiguous
+            if len(c) >= 2:
+                #check if two colors
+                comp_colors=np.unique(list(nx.get_edge_attributes(g_red_blue_ambiguous.subgraph(c), "color").values()))
+                if "blue" in comp_colors and "coral" in comp_colors and len(comp_colors)==2:#blue and coral
+                    ambiguous_node_paths.append(c)
+                    # Get the names of the edges in the subgraph of the component
+                    ambiguous_edge_paths.append(list(nx.get_edge_attributes(g_red_blue_ambiguous.subgraph(c), "name").values()))
+
+        return ambiguous_edge_paths, ambiguous_node_paths
+
+    def desambiguation_type_path(self, ambiguous_node_path: Iterable[Any], structured_graph: Any) -> str:
+        """
+        Desambiguates the type of path for ambiguous nodes based on the structured graph.
+
+        This method determines whether the ambiguous path is part of the constrained path or a loop path.
+        It uses the structured graph to identify the nodes and edges that are part of the constrained path
+        and loop paths. Based on this information, it classifies the ambiguous path as either a constrained
+        path or a loop path.
+
+        Parameters
+        ----------
+        ambiguous_node_path : list
+            A list of nodes that are part of an ambiguous path. These nodes need to be classified as either
+            part of the constrained path or a loop path.
+
+        structured_graph : Structured_Overload_Distribution_Graph
+            A structured graph with identified constrained path, hubs, and loop paths.
+
+        Returns
+        -------
+        str
+            A string indicating the type of path: "constrained_path" or "loop_path".
+        """
+        # Get the constrained path object from the structured graph
+        constrained_path_object = structured_graph.constrained_path
+
+        # Get the full list of nodes in the constrained path
+        nodes_constrained_path = constrained_path_object.full_n_constrained_path()
+
+        # Find nodes in the ambiguous path that are also in the constrained path
+        path_nodes_in_c_path = [node for node in ambiguous_node_path if node in nodes_constrained_path]
+
+        # If there are at least two nodes in the ambiguous path that are in the constrained path
+        if len(path_nodes_in_c_path) >= 2:
+            # Get the nodes upstream (amont) and downstream (aval) of the constrained path
+            nodes_amont = constrained_path_object.n_amont()
+            nodes_aval = constrained_path_object.n_aval()
+
+            # Check if the ambiguous path connects to nodes upstream of the constrained path
+            do_path_connect_amont = any([node in nodes_amont for node in path_nodes_in_c_path])
+
+            # Check if the ambiguous path connects to nodes downstream of the constrained path
+            do_path_connect_aval = any([node in nodes_aval for node in path_nodes_in_c_path])
+
+            # If the ambiguous path connects to both upstream and downstream nodes, it is a loop path
+            if do_path_connect_amont and do_path_connect_aval:
+                return "loop_path"
+            else:
+                # Otherwise, it is part of the constrained path
+                return "constrained_path"
+        elif len(path_nodes_in_c_path)==1:#if the edge connected to the constrained path is red, we can consider it on a loop path
+            return "loop_path"#"constrained_path"
+        else:
+            # If there are fewer than two nodes in the ambiguous path that are in the constrained path,
+            # it is classified as a loop path
+            return "loop_path"
+
+    def rename_nodes(self, mapping: Dict[Any, Any]) -> None:
+        self.g = nx.relabel_nodes(self.g, mapping, copy=True)
+        self.df["idx_or"]=[mapping[idx_or] for idx_or in self.df["idx_or"]]
+        self.df["idx_ex"] = [mapping[idx_or] for idx_or in self.df["idx_ex"]]
+
+    def _setup_null_flow_styles(self, non_connected_lines: List[Any], non_reconnectable_lines: List[Any]) -> List[Any]:
+        """
+        One-time setup of edge styles and directions for non-connected/non-reconnectable lines.
+        Returns pre-computed edge sets for reuse across target_path iterations.
+        """
+        non_connected_lines = list(set(non_connected_lines + non_reconnectable_lines))
+
+        edge_names = nx.get_edge_attributes(self.g, 'name')
+        edges_non_connected_lines = set(
+            edge for edge, edge_name in edge_names.items() if edge_name in non_connected_lines)
+
+        edges_non_reconnectable_lines = set(
+            edge for edge, edge_name in edge_names.items() if edge_name in non_reconnectable_lines)
+        edges_reconnectable_lines = edges_non_connected_lines - edges_non_reconnectable_lines
+
+        # Make dash and dotted lines to reconnectable vs non reconnectable lines
+        edge_attribues_to_set = {edge: {"style": "dotted"} for edge in edges_non_reconnectable_lines}
+        nx.set_edge_attributes(self.g, edge_attribues_to_set)
+
+        edge_attribues_to_set = {edge: {"style": "dashed"} for edge in edges_reconnectable_lines}
+        nx.set_edge_attributes(self.g, edge_attribues_to_set)
+
+        # Also make no direction for non reconnectable edges
+        edge_dirs = {edge: "none" for edge in edges_non_reconnectable_lines}
+        nx.set_edge_attributes(self.g, edge_dirs, "dir")
+
+        return non_connected_lines
+
+    def add_relevant_null_flow_lines_all_paths(self, structured_graph: Any, non_connected_lines: List[Any], non_reconnectable_lines: List[Any] = []) -> None:
+        """
+        Make edges bi-directionnal when flow redispatch value is null
+
+        Parameters
+        ----------
+
+        structured_graph: ``SuscturedOverflowGraph``
+            a structured graph with identified constrained path, hubs, loop paths
+
+
+        non_connected_lines: ``array``
+            list of lines that are non connected but that could be reconnected and that we want to highlight if relevant
+
+        """
+        # One-time setup: styles and directions (idempotent across target_path iterations)
+        non_connected_lines = self._setup_null_flow_styles(non_connected_lines, non_reconnectable_lines)
+
+        # Pre-compute structural info that is the same for all target_paths
+        node_red_paths = []
+        if structured_graph.red_loops.Path.shape[0] != 0:
+            node_red_paths = set(structured_graph.g_only_red_components.nodes)
+        node_amont_constrained_path = structured_graph.constrained_path.n_amont()
+        node_aval_constrained_path = structured_graph.constrained_path.n_aval()
+
+        structural_info = {
+            "node_red_paths": node_red_paths,
+            "node_amont_constrained_path": node_amont_constrained_path,
+            "node_aval_constrained_path": node_aval_constrained_path,
+        }
+
+        for target_path in ["blue_amont_aval", "red_only", "blue_to_red", "blue_only"]:
+            self.add_relevant_null_flow_lines(structured_graph, non_connected_lines, non_reconnectable_lines,
+                                              target_path=target_path,
+                                              _skip_style_setup=True,
+                                              _structural_info=structural_info)
+
+
+
+
+
+    def add_relevant_null_flow_lines(self, structured_graph: Any, non_connected_lines: List[Any],
+                                     non_reconnectable_lines: List[Any] = [], target_path: str = "blue_to_red",
+                                     depth_reconnectable_edges_search: int = 2,
+                                     max_null_flow_path_length: int = 7,
+                                     _skip_style_setup: bool = False, _structural_info: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Make edges bi-directional when flow redispatch is null, recolor the
+        relevant ones that could be of interest for analyzing or solving the
+        problem, and get back to initial edges for the others.
+
+        The orchestration is split across four helpers:
+
+        - :meth:`_prepare_null_flow_edge_sets` computes the line / edge sets
+          and "connex" candidates up front,
+        - :meth:`_build_gray_components` materialises the gray-only weakly
+          connected components used as search subgraphs,
+        - :meth:`_detect_edges_for_target_path` runs the per-component
+          ``detect_edges_to_keep`` calls for one of the four target-path
+          strategies (``blue_only`` / ``blue_amont_aval`` / ``red_only`` /
+          ``blue_to_red``),
+        - :meth:`_apply_null_flow_recoloring` paints the resulting edges and
+          cleans up unused doubled edges.
+
+        Parameters
+        ----------
+        structured_graph: ``Structured_Overload_Distribution_Graph``
+            a structured graph with identified constrained path, hubs, loop paths
+        non_connected_lines: list[str]
+            list of lines that are non connected but could be reconnected
+        non_reconnectable_lines: list[str]
+            list of lines that are non connected and cannot be reconnected
+        target_path: str
+            one of ``blue_only``, ``blue_amont_aval``, ``red_only``, ``blue_to_red``
+        """
+        if not _skip_style_setup:
+            non_connected_lines = self._setup_null_flow_styles(
+                non_connected_lines, non_reconnectable_lines)
+
+        sets = self._prepare_null_flow_edge_sets(non_connected_lines, non_reconnectable_lines)
+
+        # Make null-flow-redispatch lines bidirectional inside self.g (this
+        # mutates self.g and returns the edges we added so we can roll back
+        # the ones that turned out not to be useful at the end).
+        edges_to_double, edges_double_added = add_double_edges_null_redispatch(self.g)
+
+        # Refresh edge sets now that new edges exist
+        edge_names = nx.get_edge_attributes(self.g, 'name')
+        edges_non_connected_lines = {
+            edge for edge, n in edge_names.items() if n in sets["non_connected_lines_set"]
+        }
+        edges_non_reconnectable_lines = {
+            edge for edge, n in edge_names.items() if n in sets["non_reconnectable_lines_set"]
+        }
+
+        gray_components = self._build_gray_components()
+
+        structural_info = _structural_info or self._structural_info_for_null_flow(structured_graph)
+
+        edges_to_keep, edges_non_reconnectable = self._detect_edges_for_target_path(
+            gray_components, target_path, structural_info,
+            sets["edges_non_connected_lines_to_consider"],
+            edges_non_connected_lines,
+            edges_non_reconnectable_lines,
+            depth_reconnectable_edges_search,
+            max_null_flow_path_length,
+        )
+
+        self._apply_null_flow_recoloring(
+            target_path, edges_to_keep, edges_non_reconnectable,
+            edges_to_double, edges_double_added,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers for add_relevant_null_flow_lines
+    # ------------------------------------------------------------------
+
+    def _prepare_null_flow_edge_sets(self, non_connected_lines: List[Any], non_reconnectable_lines: List[Any]) -> Dict[str, Any]:
+        """
+        Compute the input edge sets used by :meth:`add_relevant_null_flow_lines`:
+        the plain line-name sets, plus ``edges_non_connected_lines_to_consider``
+        which keeps only lines "connex" to at least one non-gray edge (i.e.
+        lines whose reconnection could plausibly matter for the analysis).
+        """
+        non_connected_lines_set = set(non_connected_lines)
+        non_reconnectable_lines_set = set(non_reconnectable_lines)
+        edge_names = nx.get_edge_attributes(self.g, 'name')
+
+        # Nodes with at least one non-gray edge
+        edge_colors = nx.get_edge_attributes(self.g, 'color')
+        nodes_coloured = set()
+        for edge, color in edge_colors.items():
+            if color != "gray":
+                nodes_coloured.add(edge[0])
+                nodes_coloured.add(edge[1])
+
+        # Connex gray edge names — touching at least one coloured node
+        edge_connex_names = set()
+        for edge, color in edge_colors.items():
+            if color == "gray" and (edge[0] in nodes_coloured or edge[1] in nodes_coloured):
+                name = edge_names.get(edge)
+                if name:
+                    edge_connex_names.add(name)
+
+        non_connected_lines_to_consider = non_connected_lines_set & edge_connex_names
+        edges_non_connected_lines_to_consider = {
+            edge for edge, n in edge_names.items() if n in non_connected_lines_to_consider
+        }
+
+        return {
+            "non_connected_lines_set": non_connected_lines_set,
+            "non_reconnectable_lines_set": non_reconnectable_lines_set,
+            "edges_non_connected_lines_to_consider": edges_non_connected_lines_to_consider,
+        }
+
+    def _build_gray_components(self) -> List[Any]:
+        """
+        Build the list of weakly connected components consisting only of
+        "gray" edges (i.e. non-coral/blue/black). Components are returned
+        sorted by size ascending and each is a mutable copy, so the caller
+        can freely drop positive- or negative-capacity edges before running
+        path searches on them.
+        """
+        _EXCLUDED_COLORS = frozenset({"coral", "blue", "black"})
+        g_only_gray_components = nx.MultiDiGraph()
+        for u, v, k, data in self.g.edges(keys=True, data=True):
+            if data.get("color") not in _EXCLUDED_COLORS:
+                g_only_gray_components.add_edge(u, v, key=k, **data)
+        g_only_gray_components.remove_nodes_from(list(nx.isolates(g_only_gray_components)))
+
+        return [
+            g_only_gray_components.subgraph(c).copy()
+            for c in sorted(
+                nx.weakly_connected_components(g_only_gray_components),
+                key=len, reverse=False,
+            )
+        ]
+
+    @staticmethod
+    def _structural_info_for_null_flow(structured_graph: Any) -> Dict[str, Any]:
+        """Extract the red/amont/aval node sets once per call."""
+        node_red_paths = []
+        if structured_graph.red_loops.Path.shape[0] != 0:
+            node_red_paths = set(structured_graph.g_only_red_components.nodes)
+        return {
+            "node_red_paths": node_red_paths,
+            "node_amont_constrained_path": structured_graph.constrained_path.n_amont(),
+            "node_aval_constrained_path": structured_graph.constrained_path.n_aval(),
+        }
+
+    def _detect_edges_for_target_path(self, gray_components: List[Any], target_path: str, structural_info: Dict[str, Any],
+                                      edges_non_connected_lines_to_consider: Set[Any],
+                                      edges_non_connected_lines: Set[Any],
+                                      edges_non_reconnectable_lines: Set[Any],
+                                      depth_reconnectable_edges_search: int,
+                                      max_null_flow_path_length: int) -> Tuple[Set[Any], Set[Any]]:
+        """
+        Per-component dispatch to :meth:`detect_edges_to_keep` based on the
+        chosen ``target_path`` strategy. Each strategy picks a different
+        source / target node set on the shared structural_info and may
+        additionally prune positive- or negative-capacity edges from the
+        mutable gray component before running the search.
+        """
+        node_red_paths = structural_info["node_red_paths"]
+        node_amont = structural_info["node_amont_constrained_path"]
+        node_aval = structural_info["node_aval_constrained_path"]
+
+        edges_to_keep = set()
+        edges_non_reconnectable = set()
+
+        def _run(g_c, sources, targets):
+            keep, non_rec = self.detect_edges_to_keep(
+                g_c, sources, targets,
+                edges_non_connected_lines, edges_non_reconnectable_lines,
+                depth_edges_search=depth_reconnectable_edges_search,
+                max_null_flow_path_length=max_null_flow_path_length)
+            edges_to_keep.update(keep)
+            edges_non_reconnectable.update(non_rec)
+
+        for g_c in gray_components:
+            if not edges_non_connected_lines_to_consider.intersection(set(g_c.edges)):
+                continue
+
+            if target_path == "blue_only":
+                # Looking for blue (negative) edge paths — drop positive-capacity edges
+                edges_to_remove = [
+                    edge for edge, capacity in nx.get_edge_attributes(g_c, "capacity").items()
+                    if capacity > 0.
+                ]
+                g_c.remove_edges_from(edges_to_remove)
+
+                intersect_amont = set(g_c).intersection(node_amont)
+                intersect_aval = set(g_c).intersection(node_aval)
+                _run(g_c, intersect_amont, intersect_amont)
+                _run(g_c, intersect_aval, intersect_aval)
+
+            elif target_path == "blue_amont_aval":
+                intersect_amont = set(g_c).intersection(node_amont)
+                intersect_aval = set(g_c).intersection(node_aval)
+                _run(g_c, intersect_amont, intersect_aval)
+
+            elif target_path == "red_only":
+                # Looking for red (positive) edge paths — drop negative-capacity edges
+                edges_to_remove = [
+                    edge for edge, capacity in nx.get_edge_attributes(g_c, "capacity").items()
+                    if capacity < 0.
+                ]
+                g_c.remove_edges_from(edges_to_remove)
+
+                intersect_red = set(g_c).intersection(node_red_paths)
+                _run(g_c, intersect_red, intersect_red)
+
+            elif target_path == "blue_to_red":
+                intersect_amont = set(g_c).intersection(node_amont)
+                intersect_aval = set(g_c).intersection(node_aval)
+                intersect_red = set(g_c).intersection(node_red_paths)
+
+                if intersect_amont:
+                    _run(g_c, intersect_amont, intersect_red)
+                if intersect_aval:
+                    _run(g_c, intersect_red, intersect_aval)
+                # Potential new loop path using disconnected lines
+                if intersect_amont and intersect_aval:
+                    _run(g_c, intersect_amont, intersect_aval)
+
+        return edges_to_keep, edges_non_reconnectable
+
+    def _apply_null_flow_recoloring(self, target_path: str, edges_to_keep: Set[Any], edges_non_reconnectable: Set[Any],
+                                    edges_to_double: Dict[Any, Any], edges_double_added: Dict[Any, Any]) -> None:
+        """
+        Paint the detected edges and roll back the double-edges that were
+        not used. Blue/red colours follow the ``target_path`` strategy; for
+        ``blue_to_red`` we additionally look at the current capacity sign so
+        negative edges stay blue even inside a red-tagged path.
+        """
+        if target_path == "blue_only":
+            edge_attributes = {edge: {"color": "blue"} for edge in edges_to_keep}
+        elif target_path == "blue_to_red":
+            current_weights = nx.get_edge_attributes(self.g, 'capacity')
+            edge_attributes = {edge: {"color": "coral"} for edge in edges_to_keep}
+            edge_attributes.update({
+                edge: {"color": "blue"}
+                for edge in edges_to_keep
+                if current_weights[edge] < 0
+            })
+        else:
+            edge_attributes = {edge: {"color": "coral"} for edge in edges_to_keep}
+
+        # Non-reconnectable edges that were still gray get marked dimgray
+        edge_attributes.update({
+            edge: {"color": "dimgray"}
+            for edge in edges_non_reconnectable
+            if self.g.edges[edge]["color"] == "gray"
+        })
+
+        nx.set_edge_attributes(self.g, edge_attributes)
+
+        # Kept edges that came from the "double edge" trick should be drawn
+        # without an arrow tip (they represent null-flow lines).
+        doubled_edges = set(edges_to_double.values()) | set(edges_double_added.values())
+        edge_dirs = {edge: "none" for edge in edges_to_keep.intersection(doubled_edges)}
+        nx.set_edge_attributes(self.g, edge_dirs, "dir")
+
+        # Roll back unused doubled edges
+        self.g = remove_unused_added_double_edge(
+            self.g, edges_to_keep, edges_to_double, edges_double_added)
+
+    def detect_edges_to_keep(self, g_c: nx.MultiDiGraph, source_nodes: Iterable[Any], target_nodes: Iterable[Any], edges_of_interest: Set[Any],
+                             non_reconnectable_edges: List[Any] = [], depth_edges_search: int = 2,
+                             max_null_flow_path_length: int = 7) -> Tuple[Set[Any], Set[Any]]:
+        """
+        Detect edges in ``edges_of_interest`` that lie on a short path between
+        ``source_nodes`` and ``target_nodes`` inside the subgraph ``g_c``.
+
+        The work is split across five helpers:
+
+        - :meth:`_prepare_detect_edges_inputs` handles every early-exit case,
+          flips negative capacities, and collects the per-node metadata.
+        - :meth:`_compute_sssp_paths` runs one single-source Dijkstra per
+          source node with an incentivised weight function.
+        - :meth:`_collect_paths_of_interest` materialises the shortest paths
+          that actually traverse an edge of interest.
+        - :meth:`_classify_paths_by_reconnectability` splits the collected
+          paths into reconnectable / non-reconnectable edges.
+
+        Returns
+        -------
+        (set, set)
+            ``(reconnectable_edges, non_reconnectable_edges)`` — both sets of
+            MultiDiGraph edge keys.
+        """
+        prepared = self._prepare_detect_edges_inputs(
+            g_c, source_nodes, target_nodes, edges_of_interest,
+            non_reconnectable_edges, depth_edges_search)
+        if prepared is None:
+            return set(), set()
+
+        sssp_paths_cache = self._compute_sssp_paths(g_c, prepared, edges_of_interest)
+        paths_of_interest = self._collect_paths_of_interest(
+            g_c, prepared, sssp_paths_cache, max_null_flow_path_length)
+        return self._classify_paths_by_reconnectability(prepared, paths_of_interest)
+
+    # ------------------------------------------------------------------
+    # Helpers for detect_edges_to_keep
+    # ------------------------------------------------------------------
+
+    def _prepare_detect_edges_inputs(self, g_c: nx.MultiDiGraph, source_nodes: Iterable[Any], target_nodes: Iterable[Any], edges_of_interest: Set[Any],
+                                     non_reconnectable_edges: List[Any], depth_edges_search: int) -> Optional[Dict[str, Any]]:
+        """
+        Run the up-front bookkeeping shared by every branch of
+        :meth:`detect_edges_to_keep`:
+
+        - filter ``edges_of_interest`` / ``source_nodes`` / ``target_nodes``
+          down to what exists in ``g_c``,
+        - flip the sign of any negative-capacity edge (single pass),
+        - pre-compute which nodes have an incident edge of interest,
+        - pre-compute per-node BFS results for the edge-name search.
+
+        Returns ``None`` if any early-exit condition is met; otherwise a
+        dictionary with the cached structures for downstream helpers.
+        """
+        g_c_edge_names_dict = nx.get_edge_attributes(g_c, "name")
+
+        edges_of_interest_in_gc = edges_of_interest & set(g_c_edge_names_dict.keys())
+        if not edges_of_interest_in_gc:
+            return None
+
+        edge_names_of_interest = {g_c_edge_names_dict[edge] for edge in edges_of_interest_in_gc}
+        non_reconnectable_edges_names = {
+            g_c_edge_names_dict[edge] for edge in non_reconnectable_edges
+            if edge in g_c_edge_names_dict
+        }
+
+        # Flip negative capacities once (single pass)
+        new_attributes_dict = {
+            e: {"capacity": -capacity}
+            for e, capacity in nx.get_edge_attributes(g_c, "capacity").items()
+            if capacity < 0
+        }
+        if new_attributes_dict:
+            nx.set_edge_attributes(g_c, new_attributes_dict)
+
+        source_nodes_in_gc = [s for s in source_nodes if s in g_c]
+        target_nodes_in_gc = [t for t in target_nodes if t in g_c]
+        if not source_nodes_in_gc or not target_nodes_in_gc:
+            return None
+
+        unique_nodes = set(source_nodes_in_gc) | set(target_nodes_in_gc)
+        node_has_incident_interest = {}
+        for node in unique_nodes:
+            incident = set(g_c.out_edges(node, keys=True)) | set(g_c.in_edges(node, keys=True))
+            node_has_incident_interest[node] = bool(incident & edges_of_interest_in_gc)
+
+        if not any(node_has_incident_interest.values()):
+            return None
+
+        bfs_cache = {
+            node: find_multidigraph_edges_by_name(
+                g_c, node, edge_names_of_interest,
+                depth=depth_edges_search, name_attr="name")
+            for node in unique_nodes
+        }
+
+        targets_with_bfs = frozenset(t for t in target_nodes_in_gc if bfs_cache[t])
+        any_target_has_interest = any(node_has_incident_interest[t] for t in target_nodes_in_gc)
+
+        return {
+            "g_c_edge_names_dict": g_c_edge_names_dict,
+            "edges_of_interest_in_gc": edges_of_interest_in_gc,
+            "edge_names_of_interest": edge_names_of_interest,
+            "non_reconnectable_edges_names": non_reconnectable_edges_names,
+            "source_nodes_in_gc": source_nodes_in_gc,
+            "target_nodes_in_gc": target_nodes_in_gc,
+            "node_has_incident_interest": node_has_incident_interest,
+            "bfs_cache": bfs_cache,
+            "targets_with_bfs": targets_with_bfs,
+            "any_target_has_interest": any_target_has_interest,
+        }
+
+    def _compute_sssp_paths(self, g_c: nx.MultiDiGraph, prepared: Dict[str, Any], edges_of_interest: Set[Any]) -> Dict[Any, Any]:
+        """
+        Run single-source Dijkstra once per source node with a weight function
+        that massively favours low-capacity edges and gently promotes edges
+        of interest when capacities tie. Returns a dict
+        ``source_node -> {target_node -> path_nodes}``.
+        """
+        HUGE_MULTIPLIER = 1_000_000_000
+        NORMAL_HOP_COST = 100
+        PROMOTED_HOP_COST = 33
+        promoted_set = set(edges_of_interest)
+
+        def incentivized_weight(u, v, attr):
+            real_weight = attr.get("capacity", 0)
+            if real_weight < 0:
+                raise ValueError("Negative weights not allowed.")
+            is_promoted = (u, v) in promoted_set
+            hop_cost = PROMOTED_HOP_COST if is_promoted else NORMAL_HOP_COST
+            return (real_weight * HUGE_MULTIPLIER) + hop_cost
+
+        bfs_cache = prepared["bfs_cache"]
+        targets_with_bfs = prepared["targets_with_bfs"]
+        node_has_incident_interest = prepared["node_has_incident_interest"]
+        any_target_has_interest = prepared["any_target_has_interest"]
+
+        sssp_paths_cache = {}
+        for source_node in set(prepared["source_nodes_in_gc"]):
+            if not node_has_incident_interest[source_node] and not any_target_has_interest:
+                continue
+            if not bfs_cache[source_node] and not targets_with_bfs:
+                continue
+            try:
+                sssp_paths_cache[source_node] = nx.single_source_dijkstra_path(
+                    g_c, source_node, weight=incentivized_weight)
+            except Exception:
+                sssp_paths_cache[source_node] = {}
+        return sssp_paths_cache
+
+    def _collect_paths_of_interest(self, g_c: nx.MultiDiGraph, prepared: Dict[str, Any], sssp_paths_cache: Dict[Any, Any], max_null_flow_path_length: int) -> List[Any]:
+        """
+        Walk the (source, target) product and materialise the paths whose
+        node-count is within ``max_null_flow_path_length`` and which actually
+        traverse at least one edge of interest. Paths are returned sorted by
+        length so the downstream classifier can dedupe greedily.
+        """
+        source_nodes_in_gc = prepared["source_nodes_in_gc"]
+        target_nodes_in_gc = prepared["target_nodes_in_gc"]
+        bfs_cache = prepared["bfs_cache"]
+        targets_with_bfs = prepared["targets_with_bfs"]
+        node_has_incident_interest = prepared["node_has_incident_interest"]
+        edges_of_interest_in_gc = prepared["edges_of_interest_in_gc"]
+
+        paths_of_interest = []
+        for source_node in source_nodes_in_gc:
+            if source_node not in sssp_paths_cache:
+                continue
+            source_paths = sssp_paths_cache[source_node]
+            source_has_bfs = bool(bfs_cache[source_node])
+            source_has_interest = node_has_incident_interest[source_node]
+
+            for target_node in target_nodes_in_gc:
+                if source_node == target_node:
+                    continue
+                if not source_has_interest and not node_has_incident_interest[target_node]:
+                    continue
+                if not source_has_bfs and target_node not in targets_with_bfs:
+                    continue
+
+                path_nodes = source_paths.get(target_node)
+                if not path_nodes or len(path_nodes) > max_null_flow_path_length:
+                    continue
+                path = nodepath_to_edgepath(g_c, path_nodes, with_keys=True)
+                if any(edge in edges_of_interest_in_gc for edge in path):
+                    paths_of_interest.append(path)
+
+        paths_of_interest.sort(key=len)
+        return paths_of_interest
+
+    def _classify_paths_by_reconnectability(self, prepared: Dict[str, Any], paths_of_interest: List[Any]) -> Tuple[Set[Any], Set[Any]]:
+        """
+        Greedy dedupe over the sorted ``paths_of_interest``: each edge name
+        is attributed to the *first* (shortest) path that uses it, and the
+        path as a whole is classified as non-reconnectable iff any of its
+        newly-attributed edges is in the non-reconnectable edge-name set.
+        """
+        g_c_edge_names_dict = prepared["g_c_edge_names_dict"]
+        edge_names_of_interest = prepared["edge_names_of_interest"]
+        non_reconnectable_edges_names = prepared["non_reconnectable_edges_names"]
+
+        edge_names_already_found = set()
+        edges_to_keep_reconnectable = []
+        edges_to_keep_non_reconnectable = []
+
+        for path in paths_of_interest:
+            fresh_edges = {
+                edge for edge in path
+                if g_c_edge_names_dict[edge] not in edge_names_already_found
+            }
+            fresh_edge_names = {g_c_edge_names_dict[edge] for edge in fresh_edges}
+
+            if not (fresh_edge_names & edge_names_of_interest):
+                continue
+
+            if fresh_edge_names & non_reconnectable_edges_names:
+                edges_to_keep_non_reconnectable += fresh_edges
+            else:
+                edges_to_keep_reconnectable += fresh_edges
+            edge_names_already_found |= fresh_edge_names
+
+        return set(edges_to_keep_reconnectable), set(edges_to_keep_non_reconnectable)
+
+    def collapse_red_loops(self) -> None:
+        """
+        Collapse nodes that are purely part of "red loops" (coral-only edges) into point shapes.
+
+        A node is collapsed when all of the following conditions are met:
+        - All edges connected to the node (both incoming and outgoing) are "coral" coloured
+        - The node shape is simply "oval" (default shape, not a hub)
+        - The node has no "peripheries" attribute set (no electrical node number)
+        - None of the connected edges have "dashed" or "dotted" style
+        """
+        shapes = nx.get_node_attributes(self.g, "shape")
+        peripheries = nx.get_node_attributes(self.g, "peripheries")
+        edge_colors = nx.get_edge_attributes(self.g, "color")
+        edge_styles = nx.get_edge_attributes(self.g, "style")
+
+        nodes_to_collapse = {}
+
+        for node in self.g.nodes:
+            # Check shape is simply "oval"
+            if shapes.get(node) != "oval":
+                continue
+
+            # Check no peripheries attribute
+            if node in peripheries and peripheries[node]>=2:
+                continue
+
+            # Get all edges connected to this node (in and out)
+            in_edges = list(self.g.in_edges(node, keys=True))
+            out_edges = list(self.g.out_edges(node, keys=True))
+            all_edges = in_edges + out_edges
+
+            # Node must have at least one edge
+            if not all_edges:
+                continue
+
+            # Check all edges are coral and none are dashed/dotted
+            all_coral = True
+            for edge in all_edges:
+                if edge_colors.get(edge) != "coral":
+                    all_coral = False
+                    break
+                style = edge_styles.get(edge, "")
+                if style in ("dashed", "dotted"):
+                    all_coral = False
+                    break
+
+            if all_coral and all_edges:
+                nodes_to_collapse[node] = "point"
+
+        nx.set_node_attributes(self.g, nodes_to_collapse, "shape")

--- a/alphaDeesp/core/graphs/power_flow_graph.py
+++ b/alphaDeesp/core/graphs/power_flow_graph.py
@@ -1,0 +1,242 @@
+"""PowerFlowGraph: a coloured current-state power-flow graph."""
+
+import logging
+from math import fabs
+from typing import Any, Dict, List, Optional, Tuple
+
+import networkx as nx
+import numpy as np
+
+from alphaDeesp.core.printer import Printer
+from alphaDeesp.core.graphs.constants import default_voltage_colors
+
+logger = logging.getLogger(__name__)
+
+
+class PowerFlowGraph:
+    """
+    A coloured graph of current grid state with productions, consumptions and topology
+    """
+
+    def __init__(self, topo: Dict[str, Any], lines_cut: List[int], layout: Optional[List[Tuple[float, float]]] = None, float_precision: str = "%.2f") -> None:
+        """
+        Parameters
+        ----------
+
+        topo: :class:`dict`
+            dictionnary of two dictionnaries edges and nodes, to represent the grid topologie. edges have attributes "init_flows" representing the power flowing, as well as "idx_or","idx_ex"
+             for substation extremities
+             Nodes have attributes "are_prods","are_loads" if nodes have any productions or any load, as well as "prods_values","load_values" array enumerating the prod and load values at this node.
+
+        lines_cut: ``array``
+            ids of lines disconnected
+
+        float_precision: "str"
+            Significant digits for dispalyed values at edges. In the form of "%.2f"
+        """
+        self.topo=topo
+        self.lines_cut=lines_cut
+        self.layout=layout
+        self.float_precision=float_precision
+        self.build_graph()
+        #self.g=self.build_powerflow_graph()
+
+    def build_graph(self) -> None:
+        """This method creates the NetworkX Graph of the grid state"""
+        g = nx.MultiDiGraph()
+
+        # Get the id of lines that are disconnected from network
+        # lines_cut = np.argwhere(obs.line_status == False)[:, 0]
+        topo=self.topo
+
+        # Get the whole topology information
+        idx_or = topo["edges"]['idx_or']
+        idx_ex = topo["edges"]['idx_ex']
+        are_prods = topo["nodes"]['are_prods']
+        are_loads = topo["nodes"]['are_loads']
+        prods_values = topo["nodes"]['prods_values']
+        loads_values = topo["nodes"]['loads_values']
+        current_flows = topo["edges"]['init_flows']
+
+        # =========================================== NODE PART ===========================================
+        self.build_nodes(g, are_prods, are_loads, prods_values, loads_values)
+        # =========================================== EDGE PART ===========================================
+        self.build_edges(g, idx_or, idx_ex, edge_weights=current_flows)
+        #return g
+        self.g=g
+
+    def build_nodes(self, g: nx.MultiDiGraph, are_prods: Any, are_loads: Any, prods_values: Any, loads_values: Any, debug: bool = False) -> None:
+        """
+        Create nodes in graph for current grid state
+
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            a networkx graph to which to add edges
+
+        are_prods: ``array`` boolean
+            if there are productions at each node
+
+        are_loads: ``array`` boolean
+            if there are cosnumptions at each node
+
+        prods_values: ``array`` float
+            the production values at each node
+
+        loads_values: ``array`` float
+            the consumption values at each node
+
+        """
+        # =========================================== NODE PART ===========================================
+        # print(f"There are {len(are_loads)} nodes")
+        prods_iter, loads_iter = iter(prods_values), iter(loads_values)
+        i = 0
+        # We color the nodes depending if they are production or consumption
+        for is_prod, is_load in zip(are_prods, are_loads):
+            prod = next(prods_iter) if is_prod else 0.
+            load = next(loads_iter) if is_load else 0.
+            prod_minus_load = prod - load
+            if debug:
+                logger.debug("Node n°[%s] : Production value: [%s] - Load value: [%s]", i, prod, load)
+            if prod_minus_load > 0:  # PROD
+                g.add_node(i, pin=True, prod_or_load="prod", value=str(prod_minus_load), style="filled",
+                           fillcolor="coral")#orange#ff8000 #f30000")  # red color
+            elif prod_minus_load < 0:  # LOAD
+                g.add_node(i, pin=True, prod_or_load="load", value=str(prod_minus_load), style="filled",
+                           fillcolor="lightblue")#"#478fd0")  # blue color
+            else:  # WHITE COLOR
+                g.add_node(i, pin=True, prod_or_load="load", value=str(prod_minus_load), style="filled",
+                           fillcolor="#ffffed")  # white color
+            i += 1
+
+    def build_edges(self, g: nx.MultiDiGraph, idx_or: Any, idx_ex: Any, edge_weights: Any) -> None:
+
+        """
+        Create edges in graph for current grid state
+
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            a networkx graph to which to add edges
+
+        idx_or: ``array`` int
+            first extremity of edge for each edge
+
+        idx_ex: ``array`` int
+            second extremity of edge for each edge
+
+        edge_weights: ``array`` float
+            the flow value for each edge
+
+        gtype: ``str``
+            if we want a powerflow graph or
+
+        """
+
+        #if gtype is "powerflow":
+        max_abs_flow = np.abs(np.array(edge_weights)).max()
+        target_max_penwidth = 15.0
+        # Determine the scaling factor
+        if max_abs_flow > 0:
+            scaling_factor = target_max_penwidth / max_abs_flow
+        else:
+            scaling_factor = 1.0
+
+        for origin, extremity, weight_value in zip(idx_or, idx_ex, edge_weights):
+            # origin += 1
+            # extremity += 1
+            penwidth = fabs(weight_value) * scaling_factor
+            min_penwidth=0.1
+            if penwidth == 0.0:
+                penwidth = min_penwidth
+
+            if weight_value >= 0:
+                g.add_edge(origin, extremity, label=self.float_precision% weight_value, color="gray", fontsize=10,
+                           penwidth=max(float(self.float_precision % penwidth),min_penwidth))
+            else:
+                g.add_edge(extremity, origin, label=self.float_precision % fabs(weight_value), color="gray", fontsize=10,
+                           penwidth=max(float(self.float_precision % penwidth),min_penwidth))
+
+
+    def get_graph(self) -> nx.MultiDiGraph:
+        """
+        Returns the NetworkX graph representing the current state of the power flow.
+
+        Returns
+        -------
+        :class:`nx:MultiDiGraph`
+            The NetworkX graph.
+        """
+        return self.g
+
+    def set_voltage_level_color(self, voltage_levels_dict: Dict[Any, Any], voltage_colors: Dict[Any, str] = default_voltage_colors) -> None:
+        """
+        Sets the voltage level color for each node in the graph based on the provided voltage levels dictionary.
+
+        Parameters
+        ----------
+        voltage_levels_dict : dict
+            A dictionary mapping node IDs to their respective voltage levels.
+        voltage_colors : dict, optional
+            A dictionary mapping voltage levels to their corresponding colors. Defaults to `default_voltage_colors`.
+
+        Notes
+        -----
+        This method updates the 'color' attribute of each node in the graph based on the voltage levels provided.
+        """
+        voltage_levels_colors_dict = {node: voltage_colors[voltage_levels_dict[node]] for node in self.g}
+
+        nx.set_node_attributes(self.g, voltage_levels_colors_dict, "color")
+
+    def set_electrical_node_number(self, nodal_number_dict: Dict[Any, Any]) -> None:
+        """
+        Sets the electrical node number for each node in the graph based on the provided nodal number dictionary.
+
+        Parameters
+        ----------
+        nodal_number_dict : dict
+            A dictionary mapping node IDs to their respective electrical node numbers.
+
+        Notes
+        -----
+        This method updates the 'peripheries' attribute of each node in the graph based on the nodal numbers provided.
+        """
+        peripheries_dict = {node: nodal_number_dict[node] for node in self.g}
+
+        nx.set_node_attributes(self.g, peripheries_dict, "peripheries")
+
+    def plot(self, save_folder: str, name: str, state: str = "before", sim: Optional[Any] = None) -> None:
+        """
+        Plots the graph using the Printer class.
+
+        Parameters
+        ----------
+        save_folder : str
+            The folder where the plot will be saved.
+        name : str
+            The name of the plot.
+        state : str, optional
+            The state of the simulation to plot. Defaults to "before".
+        sim : object, optional
+            The simulator object, which may have a plot method. Defaults to None.
+
+        Notes
+        -----
+        If a simulator object is provided and it has a plot method, this method will use the simulator's plot method.
+        Otherwise, it will use the Printer class to display the graph.
+        """
+        printer = Printer(save_folder)
+
+        # In case the simulator also provides a plot function, use it
+        if sim is not None and hasattr(sim, 'plot'):
+            output_name = printer.create_namefile("geo", name=name, type="base")
+            if state == "before":
+                obs = sim.obs
+            else:
+                obs = sim.obs_linecut
+            sim.plot(obs, save_file_path=output_name[1])
+        else:
+            if self.layout:
+                printer.display_geo(self.g, self.layout, name=name)

--- a/alphaDeesp/core/graphs/shortest_paths.py
+++ b/alphaDeesp/core/graphs/shortest_paths.py
@@ -1,0 +1,226 @@
+"""Shortest-path helpers with mandatory / promoted-edge constraints.
+
+These live here (rather than in :mod:`graph_utils`) because they encode
+a specific optimisation strategy — minimise physical weight first, then
+favour promoted edges, then minimise hop count.
+"""
+
+from typing import Any, Iterable, List, Optional, Tuple
+
+import networkx as nx
+
+
+def shortest_path_min_weight_then_hops(G: Any, source: Any, target: Any, mandatory_edge: Tuple[Any, ...], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
+    """
+    Finds the path that:
+    1. Passes through 'mandatory_edge'
+    2. Minimizes Total Weight (Primary)
+    3. Minimizes Edge Count (Secondary/Tie-breaker)
+    """
+    # Large multiplier ensures Weight always dominates Hop Count.
+    # Must be larger than the max possible number of edges in a path (e.g., number of nodes).
+    MULTIPLIER = 1_000_000
+
+    # Define the custom weight function for Dijkstra
+    # Returns: (Actual_Weight * 1,000,000) + 1
+    def composite_weight(u, v, attr):
+        # Handle MultiDiGraph: attr might be the inner dict or we might be iterating keys
+        # nx.dijkstra_path passes the edge attribute dictionary directly
+        w = attr.get(weight_attr, 0)  # Default to 0 if no weight
+        if w < 0:
+            raise ValueError("Dijkstra does not accept negative weights.")
+        return (w * MULTIPLIER) + 1
+
+    # Unpack mandatory edge
+    u, v = mandatory_edge[0], mandatory_edge[1]
+
+    try:
+        # 1. Path Source -> u (Using composite weight)
+        path_S_to_u = nx.dijkstra_path(G, source, u, weight=composite_weight)
+
+        # 2. Path v -> Target (Using composite weight)
+        path_v_to_T = nx.dijkstra_path(G, v, target, weight=composite_weight)
+
+        # 3. Handle the mandatory edge itself
+        # We need to find the specific parallel key that minimizes (Weight, then Hops)
+        # Usually, hops is always 1 for a single edge, so just min(weight)
+        if G.is_multigraph():
+            if len(mandatory_edge) == 3:
+                # Key was specified explicitly
+                key = mandatory_edge[2]
+                mid_edge_attr = G[u][v][key]
+            else:
+                # Key not specified: Find the parallel edge with lowest weight
+                # (All parallel edges are 1 hop, so just strictly minimize weight)
+                mid_edge_attr = min(G[u][v].values(), key=lambda x: x.get(weight_attr, 0))
+        else:
+            mid_edge_attr = G[u][v]
+
+        # Calculate real final stats (without the multiplier math)
+        full_path = path_S_to_u + path_v_to_T
+
+        # Calculate strict total weight (sum of original weights)
+        # Note: We recalculate using path_weight to be precise
+        cost_S_u = nx.path_weight(G, path_S_to_u, weight=weight_attr)
+        cost_v_T = nx.path_weight(G, path_v_to_T, weight=weight_attr)
+        mid_cost = mid_edge_attr.get(weight_attr, 0)
+
+        total_real_weight = cost_S_u + mid_cost + cost_v_T
+
+        return full_path, total_real_weight
+
+    except nx.NetworkXNoPath:
+        return None, float('inf')
+
+def shortest_path_mandatory_and_promoted(G: Any, source: Any, target: Any, mandatory_edge: Tuple[Any, ...], promoted_edges: Iterable[Any], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
+    """
+    Finds a path that:
+    1. MUST pass through 'mandatory_edge'.
+    2. Minimizes Total Physical Weight (Primary constraint).
+    3. Maximizes use of 'promoted_edges' (Secondary preference).
+    4. Minimizes Total Hops (Tertiary preference).
+
+    Args:
+        G: The graph (DiGraph or MultiDiGraph).
+        source, target: Node IDs.
+        mandatory_edge: Tuple (u, v) or (u, v, key).
+        promoted_edges: List of edges to favor [(u, v), ...].
+    """
+
+    # --- Configuration ---
+    # HUGE: Ensures physical weight dominates everything (1kg of extra weight is worse than 1M extra hops)
+    HUGE_MULTIPLIER = 1_000_000_000
+
+    # COST: The "Virtual Price" of crossing an edge
+    # We prefer paying 1 dollar (Promoted) over 100 dollars (Normal)
+    NORMAL_HOP_COST = 100
+    PROMOTED_HOP_COST = 1
+
+    # Optimization: Set for O(1) lookup
+    promoted_set = set(promoted_edges)
+
+    # --- 1. Define the Custom Weight Function ---
+    def incentivized_weight(u, v, attr):
+        # A. Physical Cost
+        real_weight = attr.get(weight_attr, 0)
+        if real_weight < 0:
+            raise ValueError("Dijkstra does not accept negative weights.")
+
+        # B. Preference Cost
+        is_promoted = (u, v) in promoted_set
+
+        # Note: For MultiDiGraph, strict key checking would require iterating G[u][v]
+        # or checking if ANY parallel edge is promoted.
+        # Here we assume if the connection (u,v) is promoted, we take the bonus.
+
+        hop_cost = PROMOTED_HOP_COST if is_promoted else NORMAL_HOP_COST
+
+        # Formula: (Physical_Weight * HUGE) + Preference_Cost
+        return (real_weight * HUGE_MULTIPLIER) + hop_cost
+
+    # --- 2. Decompose the Problem ---
+    u_mand, v_mand = mandatory_edge[0], mandatory_edge[1]
+
+    try:
+        # Step A: Find best promoted path from Source -> Mandatory Start (u)
+        path_S_to_u = nx.dijkstra_path(G, source, u_mand, weight=incentivized_weight)
+
+        # Step B: Find best promoted path from Mandatory End (v) -> Target
+        path_v_to_T = nx.dijkstra_path(G, v_mand, target, weight=incentivized_weight)
+
+        # --- 3. Construct the Full Path ---
+        # path_S_to_u ends with 'u', path_v_to_T starts with 'v'
+        # We join them: [... , u] + [v, ...]
+        full_path = path_S_to_u + path_v_to_T
+
+        # --- 4. Calculate Real Stats (Optional but useful) ---
+        # We recalculate the strict physical weight to return clean data
+        cost_S_u = nx.path_weight(G, path_S_to_u, weight=weight_attr)
+        cost_v_T = nx.path_weight(G, path_v_to_T, weight=weight_attr)
+
+        # Handle the mandatory edge's own weight
+        if G.is_multigraph():
+            if len(mandatory_edge) == 3:
+                key = mandatory_edge[2]
+                mand_cost = G[u_mand][v_mand][key].get(weight_attr, 0)
+            else:
+                # If key not specified, assume the cheapest parallel line
+                mand_cost = min(d.get(weight_attr, 0) for d in G[u_mand][v_mand].values())
+        else:
+            mand_cost = G[u_mand][v_mand].get(weight_attr, 0)
+
+        total_real_weight = cost_S_u + mand_cost + cost_v_T
+
+        return full_path, total_real_weight
+
+    except nx.NetworkXNoPath:
+        return None, float('inf')
+
+def shortest_path_with_promoted_edges(G: Any, source: Any, target: Any, promoted_edges: Iterable[Any], weight_attr: str = "weight") -> Tuple[Optional[List[Any]], float]:
+    """
+    Finds a path from source to target that:
+    1. Minimizes Total Weight (Primary - strict dominance)
+    2. Maximizes use of 'promoted_edges' (Secondary)
+    3. Minimizes Total Hops (Tertiary)
+
+    Args:
+        G: The graph.
+        source, target: Node IDs.
+        promoted_edges: A list of edges to favor. Can be tuples (u, v) or (u, v, key).
+        weight_attr: The physical weight attribute name.
+    """
+
+    # Configuration
+    # HUGE: Ensures physical weight always dominates preference.
+    # PENALTY: How much we dislike normal edges.
+    #          100 means: "We prefer 3 promoted edges over 1 normal edge."
+    HUGE_MULTIPLIER = 1_000_000_000
+    NORMAL_HOP_COST = 100
+    PROMOTED_HOP_COST = 33
+
+    # 1. Optimize Lookup: Convert list to set for O(1) checking
+    # We handle both (u,v) and (u,v,key) formats
+    promoted_set = set(promoted_edges)
+
+    # 2. Define the Custom Weight Function
+    def incentivized_weight(u, v, attr):
+        # --- A. Physical Cost ---
+        real_weight = attr.get(weight_attr, 0)
+        if real_weight < 0:
+            raise ValueError("Negative weights not allowed.")
+
+        # --- B. Preference Cost ---
+        # Check if this edge is promoted
+        # (MultiGraph keys are not passed to this function in all NX versions,
+        # but 'attr' usually contains them or we check connectivity)
+
+        is_promoted = False
+
+        # Check 1: Is the specific (u, v) pair in the set?
+        if (u, v) in promoted_set:
+            is_promoted = True
+        # Check 2: If MultiGraph, is the specific key in the set?
+        elif G.is_multigraph():
+            # In some NX versions, 'attr' might not have the key directly if iterated strictly.
+            # But usually we can infer or pass keys.
+            # If your promoted_edges has keys (u, v, k), we need to match carefully.
+            # For simplicity here: if (u, v) is promoted, we treat all parallel lines as promoted
+            # UNLESS you specifically require key matching.
+            pass
+
+            # Apply costs
+        hop_cost = PROMOTED_HOP_COST if is_promoted else NORMAL_HOP_COST
+
+        # Formula: (Weight * HUGE) + Hop_Cost
+        return (real_weight * HUGE_MULTIPLIER) + hop_cost
+
+    # 3. Run Dijkstra with the Custom Weight
+    try:
+        path = nx.dijkstra_path(G, source, target, weight=incentivized_weight)
+
+        # 4. Calculate Real Metrics (for display/return)
+        total_weight = nx.path_weight(G, path, weight=weight_attr)
+        return path, total_weight
+
+    except nx.NetworkXNoPath:
+        return None, float('inf')

--- a/alphaDeesp/core/graphs/structured_overload_graph.py
+++ b/alphaDeesp/core/graphs/structured_overload_graph.py
@@ -1,0 +1,318 @@
+"""Structured_Overload_Distribution_Graph: extract constrained path,
+loop paths and hubs from a raw overflow graph.
+"""
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+import networkx as nx
+import pandas as pd
+import rustworkx as rx
+
+from alphaDeesp.core.graphs.constrained_path import ConstrainedPath
+from alphaDeesp.core.graphs.graph_utils import delete_color_edges
+from alphaDeesp.core.graphs.null_flow import (
+    add_double_edges_null_redispatch,
+    remove_unused_added_double_edge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Structured_Overload_Distribution_Graph:
+    """
+    Staring from a raw overload distribution graph with color edges, this class identifies the underlying path structure in terms of constrained path, loop paths and hub nodes
+    """
+    def __init__(self, g: nx.MultiDiGraph, possible_hubs: Optional[List[Any]] = None) -> None:
+        """
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            a raw graph from OverflowGraph
+
+        """
+        self.g_init=g
+        self.g_without_pos_edges = delete_color_edges(self.g_init, "coral") #graph without loop path that have positive/red-coloured weight edges
+        self.g_only_blue_components = delete_color_edges(self.g_without_pos_edges, "gray")
+        self.g_only_blue_components = delete_color_edges(self.g_only_blue_components, "dimgray")#also delete those edges of non reconnectable lines that we would want to visualize but is not an operational path in the structured path
+
+        self.g_without_constrained_edge = delete_color_edges(self.g_init, "black")
+        self.g_without_gray_and_c_edge = delete_color_edges(self.g_without_constrained_edge, "gray")
+        self.g_without_gray_and_c_edge = delete_color_edges(self.g_without_gray_and_c_edge, "dimgray")
+        self.g_only_red_components = delete_color_edges(self.g_without_gray_and_c_edge, "blue")#graph with only loop path that have positive/red-coloured weight edges
+
+        self.constrained_path= self.find_constrained_path() #constrained path that contains the constrained edges and their connected component of blue edges
+        self.type=""#
+        if possible_hubs is not None:#in case we already have a subset of candidates, for instance when we already built a first Overload graph and are consolidating it
+            self.hubs=possible_hubs
+        else:
+            self.hubs=[]
+        self.red_loops = self.find_loops() #parallel path to the constrained path on which flow can be rerouted
+        self.hubs = self.find_hubs() #specific nodes at substations connecting loop paths to constrained path. This is where flow can be most easily rerouted
+
+    def get_amont_blue_edges(self, g: nx.MultiDiGraph, node: Any) -> List[Any]:
+        """
+        From a given node, get blue edges (with negative overflow redispatch) that are above this node
+
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            an overflow redispatch networkx graph
+
+        node: int
+            node of interest
+
+        Returns
+        ----------
+
+        res: ``array`` int
+            ordered list of edges
+
+        """
+        res = []
+        for e in nx.edge_dfs(g, node, orientation="reverse"):
+            if g.edges[(e[0], e[1],e[2])]["color"] == "blue":
+                res.append((e[0], e[1],e[2]))
+        return res
+
+    def get_aval_blue_edges(self, g: nx.MultiDiGraph, node: Any) -> List[Any]:
+        """
+        From a given node, get blue edges (with negative overflow redispatch) that are after this node
+
+        Parameters
+        ----------
+
+        g: :class:`nx:MultiDiGraph`
+            an overflow redispatch networkx graph
+
+        node: int
+            node of interest
+
+        Returns
+        ----------
+
+        res: ``array`` int
+            ordered list of edges
+
+        """
+        res = []
+        # print("debug AlphaDeesp get aval blue edges")
+        # print(list(nx.edge_dfs(g, node, orientation="original")))
+        for e in nx.edge_dfs(g, node, orientation="original"):
+            if g.edges[(e[0], e[1],e[2])]["color"] == "blue":
+                res.append((e[0], e[1],e[2]))
+        return res
+
+
+    def find_hubs(self) -> List[Any]:
+        """
+        "A hub (carrefour_electrique) has a constrained_path and positiv reports"
+
+        Returns
+        ----------
+
+        res: list int
+            a list of nodes that are detected as hubs
+        """
+        g = self.g_without_constrained_edge
+        hubs = []
+
+        if self.constrained_path is not None:
+            logger.debug("In get_hubs(): constrained_path = %s", self.constrained_path)
+        else:
+            e_amont, constrained_edge, e_aval = self.get_constrained_path()
+            self.constrained_path = ConstrainedPath(e_amont, constrained_edge, e_aval)
+
+        # for nodes in aval, if node has RED inputs (ie incoming flows) then it is a hub
+        for node in self.constrained_path.n_aval():
+            in_edges = list(g.in_edges(node,keys=True))
+            for e in in_edges:
+                if g.edges[e]["color"] == "coral":
+                    hubs.append(node)
+                    break
+
+        # for nodes in amont, if node has RED outputs (ie outgoing flows) then it is a hub
+        for node in self.constrained_path.n_amont():
+            out_edges = list(g.out_edges(node,keys=True))
+            for e in out_edges:
+                if g.edges[e]["color"] == "coral":
+                    hubs.append(node)
+                    break
+
+        # print("get_hubs = ", hubs)
+        return hubs
+
+    def get_hubs(self) -> List[Any]:
+        return self.hubs
+
+    def find_loops(self) -> pd.DataFrame:
+
+        """This function returns all parallel paths. After discussing with Antoine, start with the most "en Aval" node,
+        and walk in reverse for loops and parallel path returns a dict with all data
+
+        Returns
+        ----------
+
+        res: pd.DataFrame
+            a dataframe with rows representing each detected path, with column attibutes "Source, Target, Path" with Path representing a list of nodes
+        """
+
+        attr_edge_direction=nx.get_edge_attributes(self.g_only_red_components, "dir")
+        if len(attr_edge_direction)!=0:
+            # add edges to make simple paths work for no direction edges
+            edges_to_double, edges_double_added = add_double_edges_null_redispatch(self.g_only_red_components,color_init="coral",only_no_dir=True)
+
+        # print("==================== In function get_loops ====================")
+        g = self.g_only_red_components
+        c_path_n = self.constrained_path.full_n_constrained_path()
+        if len(self.hubs)!=0:#already some insights of possible hubs
+            c_path_n=self.hubs
+
+        # --- 1. PRE-PROCESSING (Rustworkx) ---
+        # Convert NetworkX graph to Rustworkx for 50x speedup
+        rx_graph = rx.networkx_converter(g)
+
+        # Map Node Names (Strings) -> Node Indices (Integers)
+        nodes_list = list(g.nodes())
+        node_map = {node: i for i, node in enumerate(nodes_list)}
+
+        all_loop_paths = []
+
+        # --- 2. SEARCH LOOP ---
+        # We iterate efficiently
+        for i in range(len(c_path_n)):
+            for j in range(len(c_path_n) - 1, i, -1):
+                src_name = c_path_n[i]
+                tgt_name = c_path_n[j]
+
+                # Ensure nodes exist in the graph to avoid crashes
+                if src_name in node_map and tgt_name in node_map:
+                    s_idx = node_map[src_name]
+                    t_idx = node_map[tgt_name]
+
+                    # Rustworkx: Find all simple paths (FAST)
+                    # cutoff=10 is crucial to prevent hanging on large grids
+                    paths_indices = rx.all_simple_paths(rx_graph, s_idx, t_idx, min_depth=1)#, cutoff=10)
+
+                    # Convert Indices -> Names
+                    # We extend the main list directly
+                    paths_names = [[nodes_list[idx] for idx in p] for p in paths_indices]
+                    all_loop_paths.extend(paths_names)
+
+        # --- 3. OPTIMIZED DATAFRAME CREATION ---
+        # Instead of iterating and appending, we build lists directly.
+        # This assumes 'all_loop_paths' is a list of lists: [['A', 'B'], ['C', 'D']]
+
+        if not all_loop_paths:
+            # Handle empty case to avoid errors
+            data_for_df = {"Source": [], "Target": [], "Path": []}
+        else:
+            # List comprehensions are significantly faster than .append() loop
+            data_for_df = {
+                "Source": [p[0] for p in all_loop_paths],
+                "Target": [p[-1] for p in all_loop_paths],
+                "Path": all_loop_paths
+            }
+
+        # --- 4. GRAPH CLEANUP (Your original logic) ---
+        if len(attr_edge_direction) != 0:
+            # remove added edges that made simple paths working for no direction edges
+            self.g_only_red_components = remove_unused_added_double_edge(
+                self.g_only_red_components,
+                set(edges_to_double.values()),
+                edges_to_double,
+                edges_double_added
+            )
+
+        return pd.DataFrame(data_for_df)
+
+    def get_loops(self) -> pd.DataFrame:
+        return self.red_loops
+
+    def find_constrained_path(self) -> "ConstrainedPath":
+        """Find and return the constrained path
+
+         Returns
+        ----------
+
+        res: :class:`ConstrainedPath`
+            a constrained path object
+        """
+        constrained_edge = None
+        edge_list = nx.get_edge_attributes(self.g_only_blue_components, "color")
+        for edge, color in edge_list.items():
+            if "black" in color:
+                constrained_edge = edge
+        amont_edges = self.get_amont_blue_edges(self.g_only_blue_components, constrained_edge[0])
+        aval_edges = self.get_aval_blue_edges(self.g_only_blue_components, constrained_edge[1])
+
+        return ConstrainedPath(amont_edges,constrained_edge,aval_edges)
+
+    def get_constrained_path(self) -> "ConstrainedPath":
+        return self.constrained_path
+
+    def get_constrained_edges_nodes(self) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
+        """
+        This function identifies the constrained path within the distribution graph.
+
+        Parameters:
+        g_distribution_graph (Structured_Overload_Distribution_Graph): The structured overload distribution graph.
+
+        Returns:
+        tuple: A tuple containing two lists:
+               - edges_constrained_path: List of edges that are part of the constrained path.
+               - nodes_constrained_path: List of nodes that are part of the constrained path.
+        """
+        constrained_path_object = self.constrained_path#self.find_constrained_path()
+        nodes_constrained_path = constrained_path_object.full_n_constrained_path()
+        edges_constrained_path = []
+
+        edge_names = nx.get_edge_attributes(self.g_init, 'name')
+        edges_constrained_path += [edge_name for edge, edge_name in edge_names.items() if
+                                   edge in constrained_path_object.amont_edges]
+        edges_constrained_path += [edge_name for edge, edge_name in edge_names.items() if
+                                   edge in constrained_path_object.aval_edges]
+
+        if type(constrained_path_object.constrained_edge) is list:
+            edges_constrained_path += [edge_name for edge, edge_name in edge_names.items() if
+                                       edge in constrained_path_object.constrained_edge]
+        else:
+            edges_constrained_path.append([edge_name for edge, edge_name in edge_names.items() if
+                                           edge == constrained_path_object.constrained_edge][0])
+
+        g_blue=self.g_only_blue_components.copy()
+        g_blue.remove_edges_from(edges_constrained_path)
+
+        other_blue_edges=list(g_blue.edges())
+        other_blue_nodes=[node for node in g_blue.nodes() if node not in nodes_constrained_path]
+
+        return list(set(edges_constrained_path)), nodes_constrained_path, other_blue_edges, other_blue_nodes
+
+    def get_dispatch_edges_nodes(self, only_loop_paths: bool = True) -> Tuple[List[Any], List[Any]]:
+        """
+        This function identifies the dispatch path within the distribution graph.
+
+        Parameters:
+        g_distribution_graph (Structured_Overload_Distribution_Graph): The structured overload distribution graph.
+
+        Returns:
+        tuple: A tuple containing two lists:
+               - lines_redispatch: List of lines that are part of the dispatch path.
+               - list_nodes_dispatch_path: List of nodes that are part of the dispatch path.
+        """
+        lines_redispatch=[]
+        list_nodes_dispatch_path=[]
+        g_red = self.g_only_red_components
+
+        if only_loop_paths:
+            list_nodes_dispatch_path = list(set(self.red_loops.Path.sum()))#list(set(self.find_loops()["Path"].sum()))
+        else:
+            list_nodes_dispatch_path=list(g_red.nodes)
+
+        edge_names_red = nx.get_edge_attributes(g_red, 'name')
+        lines_redispatch=[edge_name for edge, edge_name in edge_names_red.items() if
+                                (edge[0] in list_nodes_dispatch_path) and (edge[1] in list_nodes_dispatch_path)]
+
+        return lines_redispatch, list_nodes_dispatch_path

--- a/alphaDeesp/tests/test_graphs_package.py
+++ b/alphaDeesp/tests/test_graphs_package.py
@@ -1,0 +1,443 @@
+"""Tests for the ``alphaDeesp.core.graphs`` package refactor.
+
+Complementary to ``test_graphs_and_paths_unit.py``:
+
+* :class:`TestGraphsPackageStructure` checks the *structural* invariants
+  of the refactor — shim parity, public API stability, sub-module
+  boundaries, and import acyclicity. These tests guarantee that anyone
+  who moves code around inside the package keeps the shim and the
+  documented public surface honest.
+* :class:`TestPowerFlowGraphConstruction`,
+  :class:`TestStructuredOverloadDistributionGraph` and
+  :class:`TestShortestPathMandatoryAndPromoted` provide behavioural
+  coverage for three areas that were under-tested in the legacy unit
+  file.
+"""
+import importlib
+import pkgutil
+import sys
+
+import networkx as nx
+import pytest
+
+import alphaDeesp.core.graphs as graphs_pkg
+import alphaDeesp.core.graphsAndPaths as graphs_shim
+from alphaDeesp.core.graphs import (
+    ConstrainedPath,
+    OverFlowGraph,
+    PowerFlowGraph,
+    Structured_Overload_Distribution_Graph,
+    shortest_path_mandatory_and_promoted,
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants of the refactor
+# ---------------------------------------------------------------------------
+
+# The 16 public names the refactor commits to exporting, in the same order
+# as ``alphaDeesp/core/graphs/__init__.py::__all__``.
+EXPECTED_PUBLIC_NAMES = frozenset({
+    "default_voltage_colors",
+    "PowerFlowGraph",
+    "OverFlowGraph",
+    "ConstrainedPath",
+    "Structured_Overload_Distribution_Graph",
+    "from_edges_get_nodes",
+    "delete_color_edges",
+    "nodepath_to_edgepath",
+    "incident_edges",
+    "all_simple_edge_paths_multi",
+    "find_multidigraph_edges_by_name",
+    "add_double_edges_null_redispatch",
+    "remove_unused_added_double_edge",
+    "shortest_path_min_weight_then_hops",
+    "shortest_path_mandatory_and_promoted",
+    "shortest_path_with_promoted_edges",
+})
+
+# Where each public symbol physically lives. Structural tests lock these
+# placements in so an accidental move gets caught by CI.
+EXPECTED_SYMBOL_SUBMODULE = {
+    "default_voltage_colors": "alphaDeesp.core.graphs.constants",
+    "PowerFlowGraph": "alphaDeesp.core.graphs.power_flow_graph",
+    "OverFlowGraph": "alphaDeesp.core.graphs.overflow_graph",
+    "ConstrainedPath": "alphaDeesp.core.graphs.constrained_path",
+    "Structured_Overload_Distribution_Graph":
+        "alphaDeesp.core.graphs.structured_overload_graph",
+    "from_edges_get_nodes": "alphaDeesp.core.graphs.graph_utils",
+    "delete_color_edges": "alphaDeesp.core.graphs.graph_utils",
+    "nodepath_to_edgepath": "alphaDeesp.core.graphs.graph_utils",
+    "incident_edges": "alphaDeesp.core.graphs.graph_utils",
+    "all_simple_edge_paths_multi": "alphaDeesp.core.graphs.graph_utils",
+    "find_multidigraph_edges_by_name": "alphaDeesp.core.graphs.graph_utils",
+    "add_double_edges_null_redispatch": "alphaDeesp.core.graphs.null_flow",
+    "remove_unused_added_double_edge": "alphaDeesp.core.graphs.null_flow",
+    "shortest_path_min_weight_then_hops": "alphaDeesp.core.graphs.shortest_paths",
+    "shortest_path_mandatory_and_promoted": "alphaDeesp.core.graphs.shortest_paths",
+    "shortest_path_with_promoted_edges": "alphaDeesp.core.graphs.shortest_paths",
+}
+
+EXPECTED_SUBMODULES = frozenset({
+    "constants",
+    "graph_utils",
+    "null_flow",
+    "shortest_paths",
+    "power_flow_graph",
+    "constrained_path",
+    "structured_overload_graph",
+    "overflow_graph",
+})
+
+
+class TestGraphsPackageStructure:
+    """Lock in the refactor's structural contract."""
+
+    def test_package_all_matches_expected_public_names(self):
+        assert set(graphs_pkg.__all__) == EXPECTED_PUBLIC_NAMES
+
+    def test_shim_all_matches_expected_public_names(self):
+        assert set(graphs_shim.__all__) == EXPECTED_PUBLIC_NAMES
+
+    def test_every_public_name_is_attached_to_package(self):
+        for name in EXPECTED_PUBLIC_NAMES:
+            assert hasattr(graphs_pkg, name), f"missing on package: {name}"
+
+    def test_every_public_name_is_attached_to_shim(self):
+        for name in EXPECTED_PUBLIC_NAMES:
+            assert hasattr(graphs_shim, name), f"missing on shim: {name}"
+
+    def test_shim_and_package_export_identical_objects(self):
+        """``graphsAndPaths.X is graphs.X`` for every public symbol."""
+        for name in EXPECTED_PUBLIC_NAMES:
+            assert getattr(graphs_shim, name) is getattr(graphs_pkg, name), (
+                f"shim/package identity mismatch for {name}"
+            )
+
+    def test_public_symbols_originate_from_expected_submodule(self):
+        """Each public symbol lives where the refactor says it lives.
+
+        Only classes and functions carry ``__module__`` — for module-level
+        data (``default_voltage_colors``) we instead check membership in
+        the expected sub-module's own namespace.
+        """
+        for name, expected_mod in EXPECTED_SYMBOL_SUBMODULE.items():
+            obj = getattr(graphs_pkg, name)
+            if hasattr(obj, "__module__"):
+                assert obj.__module__ == expected_mod, (
+                    f"{name} should live in {expected_mod}, "
+                    f"found in {obj.__module__}"
+                )
+            else:
+                sub = importlib.import_module(expected_mod)
+                assert getattr(sub, name) is obj, (
+                    f"{name} is not exported from {expected_mod}"
+                )
+
+    def test_all_expected_submodules_exist(self):
+        actual = {
+            m.name for m in pkgutil.iter_modules(graphs_pkg.__path__)
+            if not m.ispkg
+        }
+        assert EXPECTED_SUBMODULES.issubset(actual), (
+            f"missing submodules: {EXPECTED_SUBMODULES - actual}"
+        )
+
+    @pytest.mark.parametrize("submodule", sorted(EXPECTED_SUBMODULES))
+    def test_submodule_is_importable_in_isolation(self, submodule):
+        """Every sub-module imports cleanly on its own.
+
+        Evicting everything under ``alphaDeesp.core.graphs*`` from
+        ``sys.modules`` first ensures we catch circular imports that
+        would otherwise be hidden by a warm cache.
+        """
+        to_drop = [
+            name for name in sys.modules
+            if name == "alphaDeesp.core.graphs"
+            or name.startswith("alphaDeesp.core.graphs.")
+            or name == "alphaDeesp.core.graphsAndPaths"
+        ]
+        for name in to_drop:
+            sys.modules.pop(name, None)
+        mod = importlib.import_module(f"alphaDeesp.core.graphs.{submodule}")
+        assert mod.__name__ == f"alphaDeesp.core.graphs.{submodule}"
+
+    def test_overflow_graph_is_subclass_of_power_flow_graph(self):
+        assert issubclass(OverFlowGraph, PowerFlowGraph)
+
+    def test_shim_re_imports_do_not_duplicate_classes(self):
+        """Re-importing the shim must not create shadow copies of classes."""
+        # Use import_module rather than reload: earlier tests may have
+        # evicted the shim from sys.modules on purpose.
+        shim = importlib.import_module("alphaDeesp.core.graphsAndPaths")
+        pkg = importlib.import_module("alphaDeesp.core.graphs")
+        assert shim.OverFlowGraph is pkg.OverFlowGraph
+
+
+# ---------------------------------------------------------------------------
+# Behavioural coverage — PowerFlowGraph construction
+# ---------------------------------------------------------------------------
+
+def _simple_powerflow_topo():
+    """Minimal topology: node 0 prod, node 1 load, node 2 neutral.
+
+        0 --(+5)--> 1     (positive flow, edge kept in order)
+        1 --(-3)--> 2     (negative flow, edge gets reversed to 2 -> 1)
+    """
+    return {
+        "nodes": {
+            "are_prods":    [True,  False, False],
+            "are_loads":    [False, True,  False],
+            "prods_values": [10.0],
+            "loads_values": [8.0],
+        },
+        "edges": {
+            "idx_or":     [0, 1],
+            "idx_ex":     [1, 2],
+            "init_flows": [5.0, -3.0],
+        },
+    }
+
+
+class TestPowerFlowGraphConstruction:
+    """Construction-level tests for :class:`PowerFlowGraph`."""
+
+    def test_builds_expected_node_count(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        assert pfg.get_graph().number_of_nodes() == 3
+
+    def test_nodes_are_coloured_by_prod_minus_load(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        g = pfg.get_graph()
+        # node 0: pure producer ⇒ coral
+        assert g.nodes[0]["fillcolor"] == "coral"
+        # node 1: pure load ⇒ lightblue
+        assert g.nodes[1]["fillcolor"] == "lightblue"
+        # node 2: neutral ⇒ the off-white colour
+        assert g.nodes[2]["fillcolor"] == "#ffffed"
+
+    def test_positive_flow_edge_keeps_direction(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        g = pfg.get_graph()
+        assert g.has_edge(0, 1)
+
+    def test_negative_flow_edge_is_reversed(self):
+        """A negative init flow from idx_or→idx_ex must be drawn in reverse."""
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        g = pfg.get_graph()
+        assert g.has_edge(2, 1)
+        assert not g.has_edge(1, 2)
+
+    def test_edges_receive_gray_colour_by_default(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        g = pfg.get_graph()
+        for _, _, color in g.edges(data="color"):
+            assert color == "gray"
+
+    def test_set_electrical_node_number_sets_peripheries(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        pfg.set_electrical_node_number({0: 1, 1: 2, 2: 1})
+        g = pfg.get_graph()
+        assert g.nodes[1]["peripheries"] == 2
+
+    def test_set_voltage_level_color_applies_lookup(self):
+        pfg = PowerFlowGraph(_simple_powerflow_topo(), lines_cut=[])
+        pfg.set_voltage_level_color({0: 400, 1: 225, 2: 63})
+        g = pfg.get_graph()
+        # Uses the packaged ``default_voltage_colors`` mapping
+        assert g.nodes[0]["color"] == "red"
+        assert g.nodes[1]["color"] == "darkgreen"
+        assert g.nodes[2]["color"] == "purple"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural coverage — Structured_Overload_Distribution_Graph
+# ---------------------------------------------------------------------------
+
+def _make_structured_overload_input():
+    """Hand-built overflow graph with one constraint and one loop path.
+
+    ``A`` and ``B`` are amont nodes, ``C`` and ``D`` are aval nodes, and
+    ``X`` is a side node that carries a coral "loop" bypass::
+
+                   blue          black           blue
+            A ──────────► B ──────────► C ──────────► D
+             ╲                                         ╱
+              ╲──── coral ─────► X ──── coral ───────╱
+
+    Expected structural elements:
+      * constrained_edge = ('B', 'C', 0)
+      * constrained path = A → B → C → D
+      * loop path       = A → X → D
+      * hubs            = {A, D}
+    """
+    g = nx.MultiDiGraph()
+    # constrained path (amont -> constraint -> aval)
+    g.add_edge("A", "B", color="blue",  capacity=-5.0, name="line_AB")
+    g.add_edge("B", "C", color="black", capacity=-10.0, name="line_BC",
+               constrained=True)
+    g.add_edge("C", "D", color="blue",  capacity=-5.0, name="line_CD")
+    # loop path (coral bypass)
+    g.add_edge("A", "X", color="coral", capacity=3.0, name="line_AX")
+    g.add_edge("X", "D", color="coral", capacity=3.0, name="line_XD")
+    return g
+
+
+class TestStructuredOverloadDistributionGraph:
+    """End-to-end tests for :class:`Structured_Overload_Distribution_Graph`."""
+
+    def test_constructor_identifies_constrained_edge(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        # constrained_edge is the (u, v, key) tuple carrying the black colour
+        assert sg.constrained_path.constrained_edge[:2] == ("B", "C")
+
+    def test_full_constrained_path_walks_amont_constraint_aval(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        full = sg.constrained_path.full_n_constrained_path()
+        assert full == ["A", "B", "C", "D"]
+
+    def test_find_hubs_returns_amont_and_aval_endpoints(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        hubs = set(sg.get_hubs())
+        # A has a coral out-edge → amont hub; D has a coral in-edge → aval hub.
+        # B and C cannot be hubs (no coral neighbour on the correct side).
+        assert hubs == {"A", "D"}
+
+    def test_loops_dataframe_contains_the_bypass_path(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        loops = sg.get_loops()
+        assert not loops.empty
+        # The first path goes A → X → D via the two coral edges.
+        assert ["A", "X", "D"] in loops["Path"].tolist()
+
+    def test_get_constrained_edges_nodes_lists_named_lines(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        edges, nodes, _other_edges, _other_nodes = sg.get_constrained_edges_nodes()
+        assert set(edges) == {"line_AB", "line_BC", "line_CD"}
+        assert nodes == ["A", "B", "C", "D"]
+
+    def test_get_dispatch_edges_nodes_returns_loop_path_members(self):
+        sg = Structured_Overload_Distribution_Graph(_make_structured_overload_input())
+        lines, nodes = sg.get_dispatch_edges_nodes()
+        assert set(lines) == {"line_AX", "line_XD"}
+        assert set(nodes) == {"A", "X", "D"}
+
+
+# ---------------------------------------------------------------------------
+# Behavioural coverage — shortest_path_mandatory_and_promoted
+# ---------------------------------------------------------------------------
+
+class TestShortestPathMandatoryAndPromoted:
+    """Dedicated tests for the under-covered mandatory+promoted helper."""
+
+    def _make_three_branch_graph(self):
+        """Three parallel paths from S to T, crossing a mandatory edge M1→M2::
+
+               heavy                   heavy
+          S ───────► M1 ───────► M2 ───────► T         (weights: 10, 10)
+          S ──(1)─► X ──(1)─► M1                        (cheap, via X)
+                                    M2 ──(1)─► Y ──(1)─► T   (cheap, via Y)
+        """
+        g = nx.DiGraph()
+        # heavy direct stretches
+        g.add_edge("S", "M1", weight=10.0)
+        g.add_edge("M2", "T", weight=10.0)
+        # mandatory middle edge
+        g.add_edge("M1", "M2", weight=1.0)
+        # cheap alternates (with a promotable edge)
+        g.add_edge("S", "X", weight=1.0)
+        g.add_edge("X", "M1", weight=1.0)
+        g.add_edge("M2", "Y", weight=1.0)
+        g.add_edge("Y", "T", weight=1.0)
+        return g
+
+    def test_path_traverses_mandatory_edge(self):
+        g = self._make_three_branch_graph()
+        path, _total = shortest_path_mandatory_and_promoted(
+            g, "S", "T", mandatory_edge=("M1", "M2"),
+            promoted_edges=[], weight_attr="weight",
+        )
+        assert path is not None
+        # the (M1, M2) pair must appear somewhere in the path
+        pair_in_path = any(
+            (u, v) == ("M1", "M2")
+            for u, v in zip(path[:-1], path[1:])
+        )
+        assert pair_in_path
+
+    def test_minimises_physical_weight_over_hop_count(self):
+        g = self._make_three_branch_graph()
+        path, total = shortest_path_mandatory_and_promoted(
+            g, "S", "T", mandatory_edge=("M1", "M2"),
+            promoted_edges=[], weight_attr="weight",
+        )
+        # The cheap alternates (S→X→M1, M2→Y→T) both cost 2, versus 10
+        # for the direct heavy stretches, so the routing helper must pick
+        # the longer-but-lighter path.
+        assert path == ["S", "X", "M1", "M2", "Y", "T"]
+        assert total == pytest.approx(5.0)
+
+    def test_promoted_edges_break_weight_ties_when_cost_is_equal(self):
+        """With two alternates of identical physical weight, the promoted
+        one is preferred."""
+        g = nx.DiGraph()
+        # mandatory middle
+        g.add_edge("M1", "M2", weight=1.0)
+        # two equal-weight amont stretches: S → A → M1 vs S → B → M1
+        g.add_edge("S", "A", weight=1.0)
+        g.add_edge("A", "M1", weight=1.0)
+        g.add_edge("S", "B", weight=1.0)
+        g.add_edge("B", "M1", weight=1.0)
+        # aval: only one exit
+        g.add_edge("M2", "T", weight=1.0)
+
+        # Without promotion — Dijkstra picks *some* minimum path (ties may
+        # go either way). We cannot assert which.
+        # With promotion of the B-route, the helper must prefer it.
+        path, total = shortest_path_mandatory_and_promoted(
+            g, "S", "T", mandatory_edge=("M1", "M2"),
+            promoted_edges=[("S", "B"), ("B", "M1")],
+            weight_attr="weight",
+        )
+        assert path == ["S", "B", "M1", "M2", "T"]
+        assert total == pytest.approx(4.0)
+
+    def test_returns_none_when_no_path_exists(self):
+        g = nx.DiGraph()
+        g.add_edge("M1", "M2", weight=1.0)
+        # S and T exist in the graph (so dijkstra does not raise
+        # NodeNotFound) but are disconnected from the mandatory edge, so
+        # there is no valid routing → the helper must return (None, inf).
+        g.add_node("S")
+        g.add_node("T")
+        path, total = shortest_path_mandatory_and_promoted(
+            g, "S", "T", mandatory_edge=("M1", "M2"),
+            promoted_edges=[], weight_attr="weight",
+        )
+        assert path is None
+        assert total == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# Behavioural coverage — legacy-shim interop
+# ---------------------------------------------------------------------------
+
+class TestLegacyShimInterop:
+    """Smoke test that code importing via the legacy shim still works."""
+
+    def test_instance_built_via_shim_is_accepted_by_package_classes(self):
+        # Re-import both sides *inside* the test: an earlier parametrized
+        # test (``test_submodule_is_importable_in_isolation``) evicts
+        # ``alphaDeesp.core.graphs*`` from sys.modules to catch import
+        # cycles, which invalidates any class reference captured at
+        # module load time. Fresh imports guarantee both names point at
+        # the *current* class object in sys.modules.
+        shim = importlib.import_module("alphaDeesp.core.graphsAndPaths")
+        pkg = importlib.import_module("alphaDeesp.core.graphs")
+        cp = shim.ConstrainedPath(
+            [("A", "B", 0)], ("B", "C", 0), [("C", "D", 0)],
+        )
+        # Instance built via the shim import must be recognised by the
+        # canonical class from the package.
+        assert isinstance(cp, pkg.ConstrainedPath)
+        assert cp.full_n_constrained_path() == ["A", "B", "C", "D"]

--- a/docs/refactor-graphs-package.md
+++ b/docs/refactor-graphs-package.md
@@ -1,0 +1,230 @@
+# Refactor: `graphsAndPaths` → `alphaDeesp.core.graphs` package
+
+| Field  | Value                                                                    |
+| ------ | ------------------------------------------------------------------------ |
+| Status | Completed                                                                |
+| Scope  | `alphaDeesp/core/graphsAndPaths.py`                                      |
+| Branch | `claude/refactor-graph-module-fV6j5`                                     |
+| Impact | Zero breaking change — legacy import path kept alive via a re-export shim |
+
+## Motivation
+
+`alphaDeesp/core/graphsAndPaths.py` had grown into a 2295-line monolith
+holding four classes and a dozen module-level helpers. That shape made the
+file hard to read, hard to navigate, and hard to test:
+
+- a bug in, say, the null-flow doubling helper required scrolling past
+  several hundred lines of unrelated class methods;
+- unit tests against pure graph helpers had to import the entire module
+  (pulling in `pandas`, `rustworkx`, `Printer`, the `OverFlowGraph`
+  class, etc.) just to exercise `delete_color_edges`;
+- adding a new helper or a new graph class meant editing the same giant
+  file everyone else was editing — a recipe for merge conflicts;
+- the public surface was implicit: there was no `__all__` and callers had
+  to guess what was part of the API and what was internal.
+
+The refactor splits the monolith into a focused package of
+single-responsibility modules while **preserving behaviour byte-for-byte**.
+
+## Design principles applied
+
+- **Single Responsibility Principle.** Each sub-module holds exactly one
+  class or one tightly-related group of helpers. Any given "reason to
+  change" lands in exactly one file.
+- **Strangler-fig / façade pattern.** `graphsAndPaths.py` is not deleted —
+  it becomes a 49-line shim that re-exports everything from the new
+  package. Every existing `from alphaDeesp.core.graphsAndPaths import X`
+  keeps working. New code can progressively migrate to the direct import
+  paths.
+- **Explicit, acyclic dependency graph.** Sub-modules are layered so
+  nothing imports upwards: `constants` → `graph_utils` / `null_flow` /
+  `shortest_paths` → `constrained_path` → `structured_overload_graph` →
+  `power_flow_graph` → `overflow_graph`.
+- **Information hiding through layering.** Pure graph algorithms
+  (`graph_utils`, `null_flow`, `shortest_paths`) have zero dependency on
+  `Printer`, on `pandas.DataFrame`, or on power-flow domain concepts,
+  which makes them trivial to unit-test with hand-built `nx.MultiDiGraph`
+  fixtures.
+- **Behaviour-preserving move, not rewrite.** Class and helper bodies
+  were sliced byte-for-byte from the original file via a one-shot
+  extraction script. No algorithmic change was introduced in the refactor
+  itself — which is what makes it cheap to review and cheap to trust.
+- **Explicit public surface.** Both the package `__init__` and the legacy
+  shim define an explicit `__all__` listing the 16 exported names.
+  Anything not in that list is internal.
+
+## New layout
+
+```text
+alphaDeesp/core/graphs/
+├── __init__.py                    # public re-exports + __all__
+├── constants.py                   # default_voltage_colors
+├── graph_utils.py                 # pure graph helpers
+├── null_flow.py                   # null-flow edge doubling helpers
+├── shortest_paths.py              # mandatory/promoted Dijkstra helpers
+├── power_flow_graph.py            # PowerFlowGraph
+├── constrained_path.py            # ConstrainedPath
+├── structured_overload_graph.py   # Structured_Overload_Distribution_Graph
+└── overflow_graph.py              # OverFlowGraph
+alphaDeesp/core/graphsAndPaths.py  # backwards-compat shim
+```
+
+### Module contents
+
+**`constants`** — `default_voltage_colors` mapping `kV → graphviz colour`.
+
+**`graph_utils`** — pure helpers that operate on `networkx` graphs without
+any knowledge of the surrounding power-system domain:
+
+- `delete_color_edges`
+- `nodepath_to_edgepath`
+- `incident_edges`
+- `all_simple_edge_paths_multi`
+- `from_edges_get_nodes`
+- `find_multidigraph_edges_by_name`
+
+**`null_flow`** — helpers for making null-flow-redispatch edges
+bidirectional and for rolling back unused doubled edges:
+
+- `add_double_edges_null_redispatch`
+- `remove_unused_added_double_edge`
+
+**`shortest_paths`** — constrained shortest-path helpers built on Dijkstra
+with a composite weight function (minimise physical weight, then favour
+promoted edges, then minimise hop count):
+
+- `shortest_path_min_weight_then_hops`
+- `shortest_path_mandatory_and_promoted`
+- `shortest_path_with_promoted_edges`
+
+**`power_flow_graph`** — `PowerFlowGraph`, a coloured view of the current
+grid state (productions, consumptions, flows) built from a topology dict.
+
+**`constrained_path`** — `ConstrainedPath`, the main "constrained path"
+object: amont edges, the overloaded edge itself, and the aval edges.
+
+**`structured_overload_graph`** — `Structured_Overload_Distribution_Graph`,
+takes a raw overflow graph and extracts its structural elements:
+constrained path, loop paths, and hub nodes.
+
+**`overflow_graph`** — `OverFlowGraph`, coloured overflow-redispatch graph.
+Subclasses `PowerFlowGraph`. Holds most of the mass of the original file
+(consolidation, null-flow line detection, ambiguous-path desambiguation,
+plotting).
+
+## Dependency graph
+
+```text
+constants  ────────────────────────────────────────────┐
+                                                       │
+graph_utils ──────┐                                    │
+                  │                                    │
+null_flow ────────┼──► structured_overload_graph       │
+                  │          ▲                         │
+shortest_paths    │          │                         │
+                  │          │                         │
+constrained_path ─┘          │                         │
+                             │                         ▼
+                             └──► overflow_graph ──► power_flow_graph
+```
+
+No sub-module imports anything from a module above it in this diagram,
+which guarantees there are no import cycles. The layering is verified
+automatically by `TestGraphsPackageStructure` in
+`alphaDeesp/tests/test_graphs_package.py`.
+
+## Backwards compatibility
+
+Every consumer of the legacy module — `alphadeesp.py`,
+`expert_operator.py`, `Grid2opSimulation.py`,
+`Expert_rule_action_verification.py`, and every test file — keeps
+working **unchanged**, because `alphaDeesp/core/graphsAndPaths.py`
+re-exports all public names from `alphaDeesp.core.graphs`:
+
+```python
+# legacy (still works)
+from alphaDeesp.core.graphsAndPaths import OverFlowGraph, ConstrainedPath
+
+# preferred for new code
+from alphaDeesp.core.graphs import OverFlowGraph, ConstrainedPath
+
+# fine-grained (for unit tests of a single helper family)
+from alphaDeesp.core.graphs.graph_utils import delete_color_edges
+from alphaDeesp.core.graphs.null_flow import add_double_edges_null_redispatch
+```
+
+Instance identity is preserved across import paths: for every public
+symbol `X`, `alphaDeesp.core.graphsAndPaths.X is alphaDeesp.core.graphs.X`.
+
+## Migration guide
+
+**Existing code.** No action required. The shim keeps the old import
+path alive.
+
+**New code and new tests.** Prefer importing from `alphaDeesp.core.graphs`
+directly. When writing unit tests for a pure helper (for example
+`delete_color_edges`), import it from its sub-module so the test pulls in
+the smallest possible dependency surface:
+
+```python
+from alphaDeesp.core.graphs.graph_utils import delete_color_edges
+```
+
+**Extending the package.** Add a new class or helper to the most
+appropriate sub-module. If it does not fit any existing module, create a
+new one following the same layering rule (only import "downwards" in the
+dependency graph). Remember to:
+
+1. add the new symbol to `alphaDeesp/core/graphs/__init__.py`'s `__all__`
+   and its re-export list;
+2. mirror the addition in the legacy shim
+   `alphaDeesp/core/graphsAndPaths.py` so the backwards-compat import
+   path keeps working;
+3. add tests in `alphaDeesp/tests/test_graphs_package.py` (for structural
+   invariants) and in `alphaDeesp/tests/test_graphs_and_paths_unit.py`
+   (for behaviour).
+
+## Verification
+
+The refactor is covered by two test files:
+
+**`alphaDeesp/tests/test_graphs_and_paths_unit.py`** — pre-existing unit
+tests for every helper and every major class method. 109 tests, all
+passing against the new layout without any modification. This is the
+primary "behaviour is preserved" guarantee.
+
+**`alphaDeesp/tests/test_graphs_package.py`** — new test suite added
+alongside the refactor. Covers:
+
+- structural invariants of the refactor (shim parity, public-API
+  stability, sub-module boundaries, import acyclicity);
+- behavioural coverage of classes and helpers that were under-tested in
+  the legacy file: `PowerFlowGraph` construction,
+  `Structured_Overload_Distribution_Graph` end-to-end on a small
+  hand-built graph, and `shortest_path_mandatory_and_promoted`.
+
+Run both suites together with:
+
+```bash
+pytest alphaDeesp/tests/test_graphs_and_paths_unit.py \
+       alphaDeesp/tests/test_graphs_package.py -v
+```
+
+## Metrics
+
+| File                                    | Before | After |
+| --------------------------------------- | -----: | ----: |
+| `graphsAndPaths.py`                     |  2295  |   49  |
+| `graphs/__init__.py`                    |    —   |   50  |
+| `graphs/constants.py`                   |    —   |   13  |
+| `graphs/graph_utils.py`                 |    —   |  148  |
+| `graphs/null_flow.py`                   |    —   |   90  |
+| `graphs/shortest_paths.py`              |    —   |  226  |
+| `graphs/power_flow_graph.py`            |    —   |  242  |
+| `graphs/constrained_path.py`            |    —   |   75  |
+| `graphs/structured_overload_graph.py`   |    —   |  318  |
+| `graphs/overflow_graph.py`              |    —   | 1284  |
+
+The net +200 lines over the original monolith is made up of the added
+per-file module docstrings and import blocks. No class or helper body was
+rewritten.


### PR DESCRIPTION
## Summary

Refactors the 2295-line `alphaDeesp/core/graphsAndPaths.py` monolith into a well-organized `alphaDeesp/core/graphs/` package with single-responsibility modules. The refactor preserves all behavior byte-for-byte while improving code organization, testability, and maintainability. A backward-compatible shim in `graphsAndPaths.py` ensures zero breaking changes for existing imports.

## Key Changes

- **New package structure**: Created `alphaDeesp/core/graphs/` with 8 focused modules:
  - `power_flow_graph.py` — Base class for grid state visualization
  - `overflow_graph.py` — Colored overflow-redispatch graph (1284 lines, bulk of original logic)
  - `structured_overload_graph.py` — Extracts constrained paths, loop paths, and hubs
  - `constrained_path.py` — Main path carrying overloaded lines
  - `graph_utils.py` — Pure graph helpers (delete_color_edges, nodepath_to_edgepath, etc.)
  - `shortest_paths.py` — Shortest-path algorithms with mandatory/promoted-edge constraints
  - `null_flow.py` — Double/un-double null-flow edges
  - `constants.py` — Shared constants (voltage colors)
  - `__init__.py` — Public API re-exports

- **Backward compatibility shim**: `graphsAndPaths.py` reduced to 49 lines, re-exporting all 16 public symbols from the new package. All existing imports continue to work unchanged.

- **Explicit public API**: Added `__all__` to clearly define the 16 public names (classes, functions, constants) the package commits to exporting.

- **Comprehensive test coverage**: Added `test_graphs_package.py` with 443 lines of tests covering:
  - Structural invariants (package layout, symbol locations, import acyclicity)
  - PowerFlowGraph construction behavior
  - Structured overload graph path extraction
  - Shortest-path algorithm correctness

- **Documentation**: Added `docs/refactor-graphs-package.md` explaining motivation, design principles, and migration guidance.

## Implementation Details

- Applied Single Responsibility Principle: each module has one clear purpose
- Used strangler-fig/façade pattern: legacy import path preserved via shim
- Maintained identical behavior: no algorithmic changes, only code organization
- Ensured import acyclicity: graph classes depend on utilities, not vice versa
- Locked structural invariants with tests to prevent accidental regressions during future maintenance

https://claude.ai/code/session_01KWk5cYHneZjkrcT2LRnxCi