### PR TITLE
Bump version to 0.3.2.post2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
- 
+
+## [0.3.2.post2] - 2026-05-07
+
+### New Features
+
+- **Operator-supplied "extra lines to cut"** (PR #76): `OverFlowGraph` accepts an `extra_lines_to_cut` argument naming a subset of `lines_to_cut` that the operator chose to disconnect to prevent flow increase elsewhere (ExpertAgent's `additionalLinesToCut` semantic). Those edges keep their natural flow colour (coral/blue) instead of black/yellow, are stamped `is_extra_cut=True` (alongside `constrained=True`) so downstream consumers can find them by flag, and are excluded from `is_overload` / `is_monitored` tagging in `highlight_significant_line_loading`. The before% → after% loading annotation still fires on extras so the operator sees how their cut materialises.
+- **Interactive HTML viewer layer**: new "Extra lines to prevent flow increase" semantic layer (`semantic:is_extra_cut`) with a dashed-blue swatch, surfaced under the "Individual entities properties" section.
+
+### Tests
+
+- `TestExtraLinesToCut` in `test_overflow_graph.py` covers default empty extras, set storage, natural coral/blue colour, `is_extra_cut`/`constrained` flagging, exclusion from overload/monitored layers while still annotating the label, and the legacy "no extras" path.
+- `test_layer_index_emits_extra_cut_layer_with_endpoints` verifies the new viewer layer (endpoint nodes, swatch, label, section).
+
+
 ## [0.3.0.post1] - 2026-03-10
  
 ### New Features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Antoine Marot, Mario Jothy, Nicolas Megel'
 author = 'Antoine Marot, Mario Jothy, Nicolas Megel'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.2.post1'
+release = '0.3.2.post2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ pkgs = {
 }
 
 setup(name='ExpertOp4Grid',
-      version='0.3.2.post1',
+      version='0.3.2.post2',
       description='Expert analysis algorithm for solving overloads in a powergrid',
       long_description_content_type="text/markdown",
       python_requires=">=3.9",
@@ -50,7 +50,7 @@ setup(name='ExpertOp4Grid',
       author='Antoine Marot',
       author_email='antoine.marot@rte-france.com',
       url="https://github.com/marota/ExpertOp4Grid/",
-      download_url = 'https://github.com/marota/ExpertOp4Grid/archive/refs/tags/v0.3.2.post1.tar.gz',
+      download_url = 'https://github.com/marota/ExpertOp4Grid/archive/refs/tags/v0.3.2.post2.tar.gz',
       license='Mozilla Public License 2.0 (MPL 2.0)',
       packages=setuptools.find_packages(),
       extras_require=pkgs["extras"],


### PR DESCRIPTION
Post-release tag for the operator-supplied "extra lines to cut" feature landed via PR #76. PEP 440 ``.post2`` suffix follows the convention used by 0.3.2.post1 — a packaging refresh on top of the 0.3.2 line that extends the public API (``OverFlowGraph(extra_lines_to_cut=...)``) and ships a new interactive viewer layer without breaking existing callers.

Updates ``setup.py`` (version + download_url), ``docs/conf.py`` (release), and prepends a CHANGELOG entry summarising the change.